### PR TITLE
Prepare v1.1.1 evidence archive release

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ Stable releases are published for both `linux/amd64` and `linux/arm64` with an
 SBOM and provenance attestation:
 
 ```bash
-docker pull ghcr.io/hyeonsangjeon/kafka-metric-example:1.1.0
+docker pull ghcr.io/hyeonsangjeon/kafka-metric-example:1.1.1
 docker run --rm -p 127.0.0.1:8080:8080 \
-  ghcr.io/hyeonsangjeon/kafka-metric-example:1.1.0
+  ghcr.io/hyeonsangjeon/kafka-metric-example:1.1.1
 ```
 
 The standalone image uses the deterministic simulator and in-memory telemetry

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>dev.hyeonsangjeon</groupId>
   <artifactId>foundry-stream-lab</artifactId>
-  <version>1.1.0</version>
+  <version>1.1.1</version>
   <name>Foundry Stream Lab</name>
   <description>Privacy-safe Microsoft Foundry workload telemetry over Kafka and Vert.x</description>
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "foundry-stream-lab-web",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundry-stream-lab-web",
-      "version": "1.1.0",
+      "version": "1.1.1",
       "dependencies": {
         "lucide-react": "^1.24.0",
         "react": "^19.2.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "foundry-stream-lab-web",
   "private": true,
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "scripts": {
     "dev": "vite",


### PR DESCRIPTION
## Summary

- bump Maven and web package versions to 1.1.1
- point the README pull/run example at the 1.1.1 container
- prepare an immutable release that includes the preserved Foundry evidence and verified cleanup record

## Validation

- Java 21 Maven verify: 41 tests passed
- ESLint: passed
- Vitest: 12 tests passed
- Vite production build: passed
- release-workflow version invariants checked locally

No runtime behavior or dependency versions change in this PR.