### PR TITLE
chore: split dependency update lanes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,19 +5,111 @@ updates:
     schedule:
       interval: weekly
     groups:
+      foundry-sdk:
+        patterns:
+          - "com.azure:azure-ai-agents"
+        update-types:
+          - patch
+      azure-support:
+        patterns:
+          - "com.azure:*"
+        exclude-patterns:
+          - "com.azure:azure-ai-agents"
+        update-types:
+          - minor
+          - patch
+      java-jackson:
+        patterns:
+          - "com.fasterxml.jackson.*:*"
+        update-types:
+          - patch
       java-runtime:
-        patterns: ["*"]
+        dependency-type: production
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "com.azure:*"
+          - "com.fasterxml.jackson.*:*"
+        update-types:
+          - minor
+          - patch
+      java-build:
+        dependency-type: development
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*:*"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "com.azure:azure-ai-agents"
+        update-types:
+          - "version-update:semver-minor"
+      - dependency-name: "com.fasterxml.jackson.core:jackson-databind"
+        update-types:
+          - "version-update:semver-minor"
   - package-ecosystem: npm
     directory: /web
     schedule:
       interval: weekly
     groups:
       frontend-runtime:
-        patterns: ["*"]
+        dependency-type: production
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+      frontend-lint:
+        dependency-type: development
+        patterns:
+          - "@eslint/*"
+          - "eslint"
+          - "eslint-plugin-*"
+          - "globals"
+          - "typescript-eslint"
+        update-types:
+          - minor
+          - patch
+      frontend-types:
+        dependency-type: development
+        patterns:
+          - "@types/*"
+          - "typescript"
+        update-types:
+          - minor
+          - patch
+      frontend-tooling:
+        dependency-type: development
+        patterns:
+          - "*"
+        update-types:
+          - minor
+          - patch
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: docker
     directory: /
     schedule:
       interval: weekly
+    ignore:
+      - dependency-name: "node"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "eclipse-temurin"
+        update-types:
+          - "version-update:semver-major"
+      # Maven image tags combine Maven and JDK versions, so keep Java 21
+      # upgrades deliberate instead of accepting an unrelated JDK migration.
+      - dependency-name: "maven"
+        update-types:
+          - "version-update:semver-major"
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ RUN npm ci
 COPY web/ ./
 RUN npm run build
 
-FROM maven:3.9.11-eclipse-temurin-21 AS java-build
+FROM maven:3.9.15-eclipse-temurin-21 AS java-build
 WORKDIR /workspace/app
 COPY app/pom.xml ./
 RUN mvn --batch-mode --no-transfer-progress -DskipTests package \


### PR DESCRIPTION
## Summary
- split Maven and npm updates into compatibility-focused groups
- keep breaking runtime and toolchain migrations deliberate
- isolate patch-only Foundry SDK and Jackson updates
- update the Maven builder to 3.9.15 while retaining Java 21

## Verification
- Dependabot YAML parsed and ecosystem entries validated
- Java 21 container: 41/41 backend tests
- frontend lint, 12/12 tests, and production build
- Docker build check and full arm64 image build
- live container health + simulated fixed-profile run (2/2 completed)