### PR TITLE
docs: record verified Foundry resource cleanup

### DIFF
--- a/docs/evidence/2026-07-17-foundry-compare/README.md
+++ b/docs/evidence/2026-07-17-foundry-compare/README.md
@@ -94,10 +94,19 @@ Deliberately excluded:
 
 The screenshots retain only shortened, non-resolvable application child-run
 fragments shown by the product UI; no full application or cloud run handle is
-present. This pre-deletion bundle must be merged to the default branch before
-cleanup. After the dedicated resource group is deleted and the Foundry account
-is purged, a separate cleanup record will update this README, manifest, and
-checksums.
+present.
+
+## Cleanup verification
+
+The pre-deletion bundle was merged and checksum-verified on `origin/master`
+before cleanup. The dedicated resource group was then deleted and the Foundry
+account permanently purged. At `2026-07-17T04:06:29Z`, and again in an
+independent read-only check at `2026-07-17T04:08:13Z`, the resource group did
+not exist, the soft-deleted account match count and scoped role-assignment count
+were both zero, and the three subscription-level provider registrations were
+still `Registered` as intended. See
+[`cleanup-summary.json`](data/cleanup-summary.json) for the sanitized audit
+record.
 
 See [`manifest.json`](manifest.json) for provenance and `checksums.sha256` for
 artifact integrity.

--- a/docs/evidence/2026-07-17-foundry-compare/checksums.sha256
+++ b/docs/evidence/2026-07-17-foundry-compare/checksums.sha256
@@ -1,4 +1,4 @@
-0f61dd7ebafa0f010a4cdf5e02774ce1a1881b49f3e0c32a861336e6dc14fd0d  ./README.md
+e99fae9a2ad73f2089ec2591d8dbedf467f05db9ebaf4daf895d601311785952  ./README.md
 8a75f612f777085c26707537e7e3111b5fd1545d30d46938d30dc2bffb468561  ./charts/advanced/chart_category_latency.png
 5d9e28f0505462d300a956f96c8e2390e37f027bcb7de49edc7b3e856c61f824  ./charts/advanced/chart_latency_comparison.png
 5523562ffa3b9524807439b12251c8d09b5186636353d094ac257a7ab814df97  ./charts/advanced/chart_latency_distribution.png
@@ -15,6 +15,7 @@ bb960e815d6ba39717040e0f6357c5f0dd96147b6bc0f61a0c52fcef52c72334  ./data/applica
 e920ab0b5a308f33694351c4fb3b64ee0e31f3a59c682a565e1080ced2e0f47a  ./data/application/comparison-result.json
 54432b48a54e6e58f213149988436e9826641cc474c769397d0dd1824a165624  ./data/application/configuration-summary.json
 4c0e5ad0f7c825f79a62d1a8bb244571069d24823e18c4a3e9f2832293565cbf  ./data/application/health-summary.json
+1c70380464dd56e65924ca1cdc51092d9bddf3e4ab5fe6585d61dd9c1c5178a2  ./data/cleanup-summary.json
 d124d9c9546bcaf3ad0eb023d27190ba339da59e54173215e924d92fe375a516  ./data/evaluation-summary.json
 a16964f0edd5af7af3f064fce3f2b2f9e52c04e59104446e8b5b0ab4a419b43c  ./data/infrastructure-summary.json
 0b171bd17927c46491f94cf922c28489eb1bdc23c85b56b3874899ae1ac791db  ./data/release-summary.json
@@ -22,7 +23,7 @@ a16964f0edd5af7af3f064fce3f2b2f9e52c04e59104446e8b5b0ab4a419b43c  ./data/infrast
 1a867fbf77d63f6a946a4caca358b37d0e3d3a4f18c2abcdacba0d84dd6fa435  ./data/usage-summary.json
 dc0ca2b2fa805dd1b1be7a5cac122584b2f3f5466f431b3048dd116c7a780802  ./examples/comparison-api-io.md
 b97f021796b77d51839ad5106b1f9c854f3ab998436cf8e7a10ad3fc5b6fc358  ./examples/curated-model-io.md
-ea9e0ab3c8cc87038030216b1cff55471e49ae2d8f96710eafda82b47ed62129  ./manifest.json
+280d36beccef267986db4582fe7fac6173b771191a2489aff93b410f84eeeaef  ./manifest.json
 ae1eee801d3220cb642781781c474e2267f29ac0d37f21939ff769daace54e2a  ./screenshots/live-foundry-compare-advanced-mobile.jpg
 0c6dc3389634dd3d0e5fb1a62600f968bcfbdaa56f94be364aad55b6f2076bff  ./screenshots/live-foundry-compare-desktop.jpg
 ac13d2be0b5c966b65ba8135ce0927241d535cb8d1fdda8c82ae885d0b06907c  ./screenshots/live-foundry-compare-mobile.jpg

--- a/docs/evidence/2026-07-17-foundry-compare/data/cleanup-summary.json
+++ b/docs/evidence/2026-07-17-foundry-compare/data/cleanup-summary.json
@@ -1,0 +1,43 @@
+{
+  "status": "completed-and-verified",
+  "resourceScope": {
+    "resourceGroup": "resource-group-demo",
+    "foundryAccount": "foundry-account-demo",
+    "location": "eastus2",
+    "resourceNamesNormalized": true,
+    "boundary": "dedicated demo resource group"
+  },
+  "evidencePublication": {
+    "pullRequest": "https://github.com/hyeonsangjeon/kafka-metric-example/pull/20",
+    "mergedAtUtc": "2026-07-17T04:03:26Z",
+    "mergeCommit": "2de6f6895572ebea2d52a099b8721d9052c6733f",
+    "remoteMasterFileCount": 29,
+    "remoteMasterChecksumsVerified": 28
+  },
+  "dryRun": {
+    "completed": true,
+    "purgeIncluded": true,
+    "writeOperations": 0
+  },
+  "apply": {
+    "acceptedAtUtc": "2026-07-17T04:03:54Z",
+    "completedAtUtc": "2026-07-17T04:05:38Z",
+    "resourceGroupDeletion": true,
+    "foundryAccountPurge": true,
+    "exitCode": 0
+  },
+  "postCleanupVerification": {
+    "verifiedAtUtc": "2026-07-17T04:06:29Z",
+    "independentRecheckAtUtc": "2026-07-17T04:08:13Z",
+    "resourceGroupExists": false,
+    "softDeletedFoundryAccountMatches": 0,
+    "scopedRoleAssignments": 0,
+    "providerRegistrations": {
+      "Microsoft.CognitiveServices": "Registered",
+      "Microsoft.Insights": "Registered",
+      "Microsoft.OperationalInsights": "Registered"
+    },
+    "providerRegistrationsRetained": true
+  },
+  "gate": "Pre-delete evidence was merged and checksum-verified on origin/master before cleanup."
+}

--- a/docs/evidence/2026-07-17-foundry-compare/manifest.json
+++ b/docs/evidence/2026-07-17-foundry-compare/manifest.json
@@ -40,7 +40,7 @@
     "screenshots": 3,
     "evaluationCharts": 10,
     "examples": 2,
-    "cleanupDataFiles": 0,
+    "cleanupDataFiles": 1,
     "checksums": "checksums.sha256"
   },
   "privacy": {
@@ -52,5 +52,6 @@
     "evaluationRunAndPortalLocatorsExcluded": true,
     "demoResourceNamesNormalized": true
   },
-  "cleanupStatus": "pending-pre-delete-evidence-merge"
+  "cleanupStatus": "data/cleanup-summary.json",
+  "cleanupVerifiedAtUtc": "2026-07-17T04:08:13Z"
 }


### PR DESCRIPTION
Closes the disposable Foundry evidence lifecycle after PR #20 was merged and checksum-verified on origin/master. Records the successful dedicated resource-group deletion and permanent account purge, two read-only post-cleanup checks showing resource group absent, soft-deleted account matches zero, scoped role assignments zero, and all three subscription-level provider registrations retained. Resource names remain normalized and checksums cover every public evidence artifact.