### PR TITLE
Polish repository and prepare v1.3.0

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,14 @@
 version: 2
+
+# Maintainers batch routine version updates into reviewed, human-authored PRs.
+# A zero limit disables version-update PRs while leaving Dependabot security
+# alerts and security updates available.
 updates:
   - package-ecosystem: maven
     directory: /app
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     groups:
       foundry-sdk:
         patterns:
@@ -54,6 +59,7 @@ updates:
     directory: /web
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     groups:
       frontend-runtime:
         dependency-type: production
@@ -96,6 +102,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0
     ignore:
       - dependency-name: "node"
         update-types:
@@ -114,3 +121,4 @@ updates:
     directory: /
     schedule:
       interval: weekly
+    open-pull-requests-limit: 0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
         working-directory: app
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-      - uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
+      - uses: actions/setup-java@03ad4de0992f5dab5e18fcb136590ce7c4a0ac95 # v5.6.0
         with:
           distribution: temurin
           java-version: "21"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,7 +73,7 @@ jobs:
             org.opencontainers.image.title=Foundry Stream Lab
             org.opencontainers.image.description=Privacy-safe Foundry model-routing telemetry over Kafka and Vert.x
             org.opencontainers.image.source=https://github.com/${{ github.repository }}
-            org.opencontainers.image.licenses=Apache-2.0
+            org.opencontainers.image.licenses=MIT
 
       - name: Build and push image
         id: push
@@ -90,7 +90,7 @@ jobs:
           sbom: true
 
       - name: Attest image provenance
-        uses: actions/attest@a1948c3f048ba23858d222213b7c278aabede763 # v4.1.1
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.push.outputs.digest }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,3 +22,9 @@ mode fully functional without cloud credentials.
 
 Please use conventional, intent-focused commit messages and keep unrelated
 refactors out of feature pull requests.
+
+## Contribution license
+
+By submitting a contribution, you agree that it may be distributed under the
+project's [MIT License](LICENSE). Third-party code must retain its original
+license and attribution.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN npm run build
 
 FROM maven:3.9.15-eclipse-temurin-21 AS java-build
 WORKDIR /workspace/app
+COPY LICENSE NOTICE THIRD_PARTY_NOTICES.md /workspace/
+COPY LICENSES /workspace/LICENSES
 COPY app/pom.xml ./
 RUN mvn --batch-mode --no-transfer-progress -DskipTests package \
     && rm -rf target
@@ -15,16 +17,20 @@ COPY --from=web-build /workspace/web/dist ./src/main/resources/webroot
 RUN mvn --batch-mode --no-transfer-progress -DskipTests package
 
 FROM eclipse-temurin:21-jre-ubi10-minimal
-LABEL org.opencontainers.image.source="https://github.com/hyeonsangjeon/kafka-metric-example" \
+LABEL org.opencontainers.image.source="https://github.com/hyeonsangjeon/foundry-stream-lab" \
       org.opencontainers.image.title="Foundry Stream Lab" \
       org.opencontainers.image.description="Privacy-safe Microsoft Foundry workload telemetry over Kafka and Vert.x" \
-      org.opencontainers.image.licenses="Apache-2.0"
+      org.opencontainers.image.licenses="MIT"
 RUN groupadd --gid 10001 streamlab \
     && useradd --uid 10001 --gid streamlab --no-create-home \
       --home-dir /nonexistent --shell /bin/false streamlab
 WORKDIR /app
 COPY --from=java-build --chown=streamlab:streamlab \
   /workspace/app/target/foundry-stream-lab.jar /app/foundry-stream-lab.jar
+COPY --from=java-build --chown=streamlab:streamlab \
+  /workspace/LICENSE /workspace/NOTICE /workspace/THIRD_PARTY_NOTICES.md /licenses/
+COPY --from=java-build --chown=streamlab:streamlab \
+  /workspace/LICENSES /licenses/history
 
 USER 10001:10001
 EXPOSE 8080

--- a/LICENSE
+++ b/LICENSE
@@ -1,201 +1,21 @@
-                                 Apache License
-                           Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+MIT License
 
-   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Copyright (c) 2019-2026 Hyeonsang Jeon
 
-   1. Definitions.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-      "License" shall mean the terms and conditions for use, reproduction,
-      and distribution as defined by Sections 1 through 9 of this document.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-      "Licensor" shall mean the copyright owner or entity authorized by
-      the copyright owner that is granting the License.
-
-      "Legal Entity" shall mean the union of the acting entity and all
-      other entities that control, are controlled by, or are under common
-      control with that entity. For the purposes of this definition,
-      "control" means (i) the power, direct or indirect, to cause the
-      direction or management of such entity, whether by contract or
-      otherwise, or (ii) ownership of fifty percent (50%) or more of the
-      outstanding shares, or (iii) beneficial ownership of such entity.
-
-      "You" (or "Your") shall mean an individual or Legal Entity
-      exercising permissions granted by this License.
-
-      "Source" form shall mean the preferred form for making modifications,
-      including but not limited to software source code, documentation
-      source, and configuration files.
-
-      "Object" form shall mean any form resulting from mechanical
-      transformation or translation of a Source form, including but
-      not limited to compiled object code, generated documentation,
-      and conversions to other media types.
-
-      "Work" shall mean the work of authorship, whether in Source or
-      Object form, made available under the License, as indicated by a
-      copyright notice that is included in or attached to the work
-      (an example is provided in the Appendix below).
-
-      "Derivative Works" shall mean any work, whether in Source or Object
-      form, that is based on (or derived from) the Work and for which the
-      editorial revisions, annotations, elaborations, or other modifications
-      represent, as a whole, an original work of authorship. For the purposes
-      of this License, Derivative Works shall not include works that remain
-      separable from, or merely link (or bind by name) to the interfaces of,
-      the Work and Derivative Works thereof.
-
-      "Contribution" shall mean any work of authorship, including
-      the original version of the Work and any modifications or additions
-      to that Work or Derivative Works thereof, that is intentionally
-      submitted to Licensor for inclusion in the Work by the copyright owner
-      or by an individual or Legal Entity authorized to submit on behalf of
-      the copyright owner. For the purposes of this definition, "submitted"
-      means any form of electronic, verbal, or written communication sent
-      to the Licensor or its representatives, including but not limited to
-      communication on electronic mailing lists, source code control systems,
-      and issue tracking systems that are managed by, or on behalf of, the
-      Licensor for the purpose of discussing and improving the Work, but
-      excluding communication that is conspicuously marked or otherwise
-      designated in writing by the copyright owner as "Not a Contribution."
-
-      "Contributor" shall mean Licensor and any individual or Legal Entity
-      on behalf of whom a Contribution has been received by Licensor and
-      subsequently incorporated within the Work.
-
-   2. Grant of Copyright License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      copyright license to reproduce, prepare Derivative Works of,
-      publicly display, publicly perform, sublicense, and distribute the
-      Work and such Derivative Works in Source or Object form.
-
-   3. Grant of Patent License. Subject to the terms and conditions of
-      this License, each Contributor hereby grants to You a perpetual,
-      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
-      (except as stated in this section) patent license to make, have made,
-      use, offer to sell, sell, import, and otherwise transfer the Work,
-      where such license applies only to those patent claims licensable
-      by such Contributor that are necessarily infringed by their
-      Contribution(s) alone or by combination of their Contribution(s)
-      with the Work to which such Contribution(s) was submitted. If You
-      institute patent litigation against any entity (including a
-      cross-claim or counterclaim in a lawsuit) alleging that the Work
-      or a Contribution incorporated within the Work constitutes direct
-      or contributory patent infringement, then any patent licenses
-      granted to You under this License for that Work shall terminate
-      as of the date such litigation is filed.
-
-   4. Redistribution. You may reproduce and distribute copies of the
-      Work or Derivative Works thereof in any medium, with or without
-      modifications, and in Source or Object form, provided that You
-      meet the following conditions:
-
-      (a) You must give any other recipients of the Work or
-          Derivative Works a copy of this License; and
-
-      (b) You must cause any modified files to carry prominent notices
-          stating that You changed the files; and
-
-      (c) You must retain, in the Source form of any Derivative Works
-          that You distribute, all copyright, patent, trademark, and
-          attribution notices from the Source form of the Work,
-          excluding those notices that do not pertain to any part of
-          the Derivative Works; and
-
-      (d) If the Work includes a "NOTICE" text file as part of its
-          distribution, then any Derivative Works that You distribute must
-          include a readable copy of the attribution notices contained
-          within such NOTICE file, excluding those notices that do not
-          pertain to any part of the Derivative Works, in at least one
-          of the following places: within a NOTICE text file distributed
-          as part of the Derivative Works; within the Source form or
-          documentation, if provided along with the Derivative Works; or,
-          within a display generated by the Derivative Works, if and
-          wherever such third-party notices normally appear. The contents
-          of the NOTICE file are for informational purposes only and
-          do not modify the License. You may add Your own attribution
-          notices within Derivative Works that You distribute, alongside
-          or as an addendum to the NOTICE text from the Work, provided
-          that such additional attribution notices cannot be construed
-          as modifying the License.
-
-      You may add Your own copyright statement to Your modifications and
-      may provide additional or different license terms and conditions
-      for use, reproduction, or distribution of Your modifications, or
-      for any such Derivative Works as a whole, provided Your use,
-      reproduction, and distribution of the Work otherwise complies with
-      the conditions stated in this License.
-
-   5. Submission of Contributions. Unless You explicitly state otherwise,
-      any Contribution intentionally submitted for inclusion in the Work
-      by You to the Licensor shall be under the terms and conditions of
-      this License, without any additional terms or conditions.
-      Notwithstanding the above, nothing herein shall supersede or modify
-      the terms of any separate license agreement you may have executed
-      with Licensor regarding such Contributions.
-
-   6. Trademarks. This License does not grant permission to use the trade
-      names, trademarks, service marks, or product names of the Licensor,
-      except as required for reasonable and customary use in describing the
-      origin of the Work and reproducing the content of the NOTICE file.
-
-   7. Disclaimer of Warranty. Unless required by applicable law or
-      agreed to in writing, Licensor provides the Work (and each
-      Contributor provides its Contributions) on an "AS IS" BASIS,
-      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
-      implied, including, without limitation, any warranties or conditions
-      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
-      PARTICULAR PURPOSE. You are solely responsible for determining the
-      appropriateness of using or redistributing the Work and assume any
-      risks associated with Your exercise of permissions under this License.
-
-   8. Limitation of Liability. In no event and under no legal theory,
-      whether in tort (including negligence), contract, or otherwise,
-      unless required by applicable law (such as deliberate and grossly
-      negligent acts) or agreed to in writing, shall any Contributor be
-      liable to You for damages, including any direct, indirect, special,
-      incidental, or consequential damages of any character arising as a
-      result of this License or out of the use or inability to use the
-      Work (including but not limited to damages for loss of goodwill,
-      work stoppage, computer failure or malfunction, or any and all
-      other commercial damages or losses), even if such Contributor
-      has been advised of the possibility of such damages.
-
-   9. Accepting Warranty or Additional Liability. While redistributing
-      the Work or Derivative Works thereof, You may choose to offer,
-      and charge a fee for, acceptance of support, warranty, indemnity,
-      or other liability obligations and/or rights consistent with this
-      License. However, in accepting such obligations, You may act only
-      on Your own behalf and on Your sole responsibility, not on behalf
-      of any other Contributor, and only if You agree to indemnify,
-      defend, and hold each Contributor harmless for any liability
-      incurred by, or claims asserted against, such Contributor by reason
-      of your accepting any such warranty or additional liability.
-
-   END OF TERMS AND CONDITIONS
-
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright 2019-2026 Hyeonsang Jeon
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSES/Apache-2.0.txt
+++ b/LICENSES/Apache-2.0.txt
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,10 +1,16 @@
 Foundry Stream Lab
 Copyright 2019-2026 Hyeonsang Jeon
 
-This repository began as a dashboard derived from the Apache Vert.x
-`vertx-examples/kafka-examples` project. The 2026 rewrite removed the legacy
-source code and bundled third-party UI assets, while retaining this notice to
-preserve project provenance.
+Project-authored files in the current rewritten tree are licensed under the
+MIT License. This repository began as a dashboard derived from the Apache
+Vert.x `vertx-examples/kafka-examples` project. The 2026 rewrite removed the
+legacy source code and bundled third-party UI assets while retaining this
+notice to preserve project provenance.
+
+Historical revisions and releases through v1.2.0 remain under the license that
+accompanied them. The canonical Apache License 2.0 text is retained at
+LICENSES/Apache-2.0.txt. Third-party components retain their own licenses; see
+THIRD_PARTY_NOTICES.md and the license metadata packaged with build artifacts.
 
 Apache Vert.x and Apache Kafka are trademarks of their respective owners.
 Microsoft Foundry is a trademark of Microsoft Corporation. This project is an

--- a/README.md
+++ b/README.md
@@ -1,25 +1,30 @@
 # Foundry Stream Lab
 
-Compare a fixed model with both the default Balanced Model Router and a custom
-Cost/Quality router on the same bounded AI workload, inject one reliability
-failure, and watch privacy-safe telemetry move through Kafka in real time.
+[![CI](https://github.com/hyeonsangjeon/foundry-stream-lab/actions/workflows/ci.yml/badge.svg?branch=master)](https://github.com/hyeonsangjeon/foundry-stream-lab/actions/workflows/ci.yml)
+[![Latest release](https://img.shields.io/github/v/release/hyeonsangjeon/foundry-stream-lab)](https://github.com/hyeonsangjeon/foundry-stream-lab/releases/latest)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-Foundry Stream Lab is a complete rebuild of the original Kafka metrics demo.
-It keeps the useful idea—`event -> Kafka -> projection -> live dashboard`—and
-replaces the 2019-era runtime and vendored admin theme with a focused Microsoft
-Foundry routing, evaluation, and observability lab.
+**A local-first lab for separating AI model-routing latency from Kafka delivery
+failures.**
 
-![Completed three-profile Compare Run in the deterministic simulator](docs/design/compare-run-simulator-desktop.jpg)
+Replay one unchanged workload across **Fixed → Default/Balanced →
+Advanced/Cost or Quality** profiles. Inject model throttling, consumer slowdown,
+duplicate delivery, or a hot partition, then compare p50/p95 latency, retries,
+tokens, model mix, Kafka lag, and partition skew in a privacy-safe live
+dashboard.
 
-The screen above is the credential-free simulator path. A disposable 2026-07-16
-Foundry environment was also captured before cleanup. Start with the
-[live evidence bundle](docs/evidence/2026-07-16-foundry-live/README.md),
-follow [the presenter runbook](docs/demo-runbook.md), or inspect the
-[HTTP input/output examples](docs/api-examples.md). The bundle includes actual
-fixed/default/advanced screenshots, sanitized routing and token telemetry,
-managed tracing and Evaluation aggregates, Azure Monitor usage, 12 evaluation
-charts, one curated synthetic model I/O example, checksums, and the resource
-cleanup record.
+- **Zero-cloud default:** deterministic simulator, Kafka KRaft, and the React
+  dashboard through Docker Compose.
+- **Local model:** Ollama through its OpenAI-compatible Responses API as a
+  fixed-model profile.
+- **Real routing:** Microsoft Foundry fixed and Model Router deployments, with
+  evaluation, managed tracing, and sanitized evidence tooling.
+
+[Try it locally](#quick-start) ·
+[See a real Foundry Compare Run](docs/evidence/2026-07-17-foundry-compare/README.md) ·
+[Follow the demo runbook](docs/demo-runbook.md)
+
+![Completed three-profile Compare Run](docs/design/compare-run-simulator-desktop.jpg)
 
 ## Why this exists
 
@@ -62,9 +67,9 @@ Stable releases are published for both `linux/amd64` and `linux/arm64` with an
 SBOM and provenance attestation:
 
 ```bash
-docker pull ghcr.io/hyeonsangjeon/kafka-metric-example:1.2.0
+docker pull ghcr.io/hyeonsangjeon/foundry-stream-lab:1.3.0
 docker run --rm -p 127.0.0.1:8080:8080 \
-  ghcr.io/hyeonsangjeon/kafka-metric-example:1.2.0
+  ghcr.io/hyeonsangjeon/foundry-stream-lab:1.3.0
 ```
 
 The standalone image uses the deterministic simulator and in-memory telemetry
@@ -82,6 +87,18 @@ transport by default. Use the Compose quick start for the complete Kafka path.
    **Model throttling** to inspect the bounded retry in trace details.
 
 See [the scenario guide](docs/scenarios.md) for a presenter-ready script.
+
+## Verified live evidence
+
+The [v1.2.0 Foundry Compare Run bundle](docs/evidence/2026-07-17-foundry-compare/README.md)
+preserves a real fixed/default/advanced run, responsive screenshots, allowlisted
+API input/output, curated model responses, local and managed evaluation charts,
+content-redacted tracing, Azure Monitor usage, release provenance, checksums,
+and the verified resource deletion/purge record. It uses only synthetic prompts
+and normalizes cloud resource names and locator IDs.
+
+The earlier [single-profile live capture](docs/evidence/2026-07-16-foundry-live/README.md)
+remains available as historical evidence.
 
 ## Architecture
 
@@ -200,7 +217,7 @@ wrapper around Microsoft's Model Router Auto Evaluation toolkit under
 `tools/foundry/`. See [the Foundry guide](docs/foundry.md) for the complete live
 workflow and the boundaries of the recorded verification; the aggregate benchmark
 is recorded in [the live evaluation note](docs/live-evaluation.md), with its
-sanitized artifacts in the [evidence bundle](docs/evidence/2026-07-16-foundry-live/README.md).
+sanitized artifacts in the [Compare Run evidence bundle](docs/evidence/2026-07-17-foundry-compare/README.md).
 
 ## Privacy boundary
 
@@ -264,8 +281,19 @@ a local reliability lab, not a production Kafka, identity, or multi-tenant
 deployment template. Production boundaries are documented in
 [SECURITY.md](SECURITY.md).
 
+## Project history
+
+Foundry Stream Lab is a complete 2026 rebuild of the original Kafka metrics
+demo. It keeps the useful `event -> Kafka -> projection -> live dashboard`
+idea while replacing the legacy Java/runtime path and vendored admin theme with
+a focused Microsoft Foundry routing, evaluation, and observability lab. See
+[the migration and provenance note](docs/migration.md).
+
 ## License and provenance
 
-Apache-2.0. See [LICENSE](LICENSE) and [NOTICE](NOTICE). The rebuild credits the
-original Vert.x example lineage while removing the old vendored UI assets and
-their ambiguous redistribution surface.
+The current rewritten source tree is licensed under the [MIT License](LICENSE).
+[NOTICE](NOTICE) preserves the original Vert.x example lineage, and
+[third-party notices](THIRD_PARTY_NOTICES.md) cover distributed dependencies.
+Historical revisions and releases through `v1.2.0` remain under the license
+that accompanied them; the canonical Apache-2.0 text is retained under
+[`LICENSES`](LICENSES/Apache-2.0.txt).

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,0 +1,233 @@
+# Third-party notices
+
+Foundry Stream Lab is MIT-licensed, but its dependencies remain under their
+own licenses. Release images include an SBOM with the exact resolved versions.
+The backend build also generates `META-INF/foundry-stream-lab-THIRD-PARTY.txt`
+with the exact resolved dependency inventory. Apache-licensed components retain
+the Apache License and merged notices in the shaded JAR. This file preserves
+the redistribution notices for non-Apache backend components and code bundled
+into the browser application. For dual-licensed JNA and Vert.x components, this
+distribution uses the Apache License 2.0 option.
+
+## Azure SDK for Java
+
+Resolved packages at the time of this notice: Azure AI Agents 2.0.1, Azure
+Core 1.57.1, Azure Core HTTP OkHttp 1.13.5, Azure Identity 1.18.4, Azure JSON
+1.5.1, and Azure XML 1.2.1. These packages are licensed under the MIT License.
+
+Copyright (c) 2015 Microsoft
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Microsoft Authentication Library for Java
+
+Resolved packages at the time of this notice: MSAL4J 1.23.1 and the MSAL4J
+Persistence Extension 1.3.0. These packages are licensed under the MIT License.
+
+Copyright (c) Microsoft Corporation. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## SLF4J
+
+Resolved packages at the time of this notice: SLF4J API 1.7.36 and SLF4J
+Simple 1.7.36. These packages are licensed under the MIT License.
+
+Copyright (c) 2004-2022 QOS.ch Sarl (Switzerland)
+All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## zstd-jni
+
+Resolved version at the time of this notice: zstd-jni 1.5.6-10. The Java/JNI
+wrapper is licensed under the BSD 2-Clause License.
+
+Copyright (c) 2015-present, Luben Karavelov/ All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+The bundled Zstandard 1.5.6 native library is licensed under the BSD 3-Clause
+License.
+
+Copyright (c) 2016-present, Facebook, Inc. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+- Redistributions of source code must retain the above copyright notice,
+  this list of conditions and the following disclaimer.
+- Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+- Neither the name Facebook nor the names of its contributors may be used to
+  endorse or promote products derived from this software without specific
+  prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+## Reactive Streams
+
+Resolved version at the time of this notice: Reactive Streams 1.0.4. It is
+licensed under the MIT No Attribution License.
+
+Copyright 2014 Reactive Streams
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## React, React DOM, and Scheduler
+
+Resolved versions at the time of this notice: React 19.2.7, React DOM 19.2.7,
+and Scheduler 0.27.0. These packages are licensed under the MIT License.
+
+Copyright (c) Meta Platforms, Inc. and affiliates.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+## Lucide React
+
+Resolved version at the time of this notice: Lucide React 1.24.0. Lucide is
+licensed under the ISC License.
+
+Copyright (c) 2026 Lucide Icons and Contributors
+
+Permission to use, copy, modify, and/or distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE
+USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Some Lucide icons are derived from the Feather project and retain its MIT
+License.
+
+Copyright (c) 2013-present Cole Bemis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/app/pom.xml
+++ b/app/pom.xml
@@ -6,19 +6,33 @@
 
   <groupId>dev.hyeonsangjeon</groupId>
   <artifactId>foundry-stream-lab</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0</version>
   <name>Foundry Stream Lab</name>
   <description>Privacy-safe Microsoft Foundry workload telemetry over Kafka and Vert.x</description>
+  <url>https://github.com/hyeonsangjeon/foundry-stream-lab</url>
+  <scm>
+    <connection>scm:git:https://github.com/hyeonsangjeon/foundry-stream-lab.git</connection>
+    <developerConnection>scm:git:ssh://git@github.com/hyeonsangjeon/foundry-stream-lab.git</developerConnection>
+    <url>https://github.com/hyeonsangjeon/foundry-stream-lab</url>
+    <tag>HEAD</tag>
+  </scm>
+  <licenses>
+    <license>
+      <name>MIT License</name>
+      <url>https://opensource.org/license/mit</url>
+      <distribution>repo</distribution>
+    </license>
+  </licenses>
 
   <properties>
     <maven.compiler.release>21</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <vertx.version>5.1.5</vertx.version>
     <kafka.version>4.3.1</kafka.version>
-    <azure.ai.agents.version>2.0.0</azure.ai.agents.version>
-    <azure.identity.version>1.18.2</azure.identity.version>
+    <azure.ai.agents.version>2.0.1</azure.ai.agents.version>
+    <azure.identity.version>1.18.4</azure.identity.version>
     <jackson.databind.version>2.18.9</jackson.databind.version>
-    <junit.version>5.12.2</junit.version>
+    <junit.version>5.14.4</junit.version>
   </properties>
 
   <dependencyManagement>
@@ -56,7 +70,7 @@
     <dependency>
       <groupId>com.azure</groupId>
       <artifactId>azure-core-http-okhttp</artifactId>
-      <version>1.13.3</version>
+      <version>1.13.5</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>
@@ -109,7 +123,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>3.14.0</version>
+        <version>3.15.0</version>
         <configuration>
           <release>${maven.compiler.release}</release>
           <parameters>true</parameters>
@@ -121,7 +135,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>3.5.3</version>
+        <version>3.5.6</version>
         <configuration>
           <useModulePath>false</useModulePath>
         </configuration>
@@ -129,7 +143,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
-        <version>3.6.0</version>
+        <version>3.6.2</version>
         <executions>
           <execution>
             <phase>package</phase>
@@ -153,6 +167,18 @@
                   <mainClass>dev.hyeonsangjeon.observatory.Main</mainClass>
                 </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/LICENSE-foundry-stream-lab.txt</resource>
+                  <file>${project.basedir}/../LICENSE</file>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/NOTICE-foundry-stream-lab.txt</resource>
+                  <file>${project.basedir}/../NOTICE</file>
+                </transformer>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.IncludeResourceTransformer">
+                  <resource>META-INF/THIRD_PARTY_NOTICES.md</resource>
+                  <file>${project.basedir}/../THIRD_PARTY_NOTICES.md</file>
+                </transformer>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.AppendingTransformer">
@@ -162,6 +188,27 @@
                   <resource>META-INF/io.netty.versions.properties</resource>
                 </transformer>
               </transformers>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>license-maven-plugin</artifactId>
+        <version>2.7.1</version>
+        <executions>
+          <execution>
+            <id>runtime-third-party-report</id>
+            <phase>generate-resources</phase>
+            <goals>
+              <goal>add-third-party</goal>
+            </goals>
+            <configuration>
+              <includeTransitiveDependencies>true</includeTransitiveDependencies>
+              <includedScopes>compile,runtime</includedScopes>
+              <failOnMissing>true</failOnMissing>
+              <generateBundle>true</generateBundle>
+              <bundleThirdPartyPath>META-INF/foundry-stream-lab-THIRD-PARTY.txt</bundleThirdPartyPath>
             </configuration>
           </execution>
         </executions>

--- a/docs/contracts/telemetry-event-v1.schema.json
+++ b/docs/contracts/telemetry-event-v1.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/hyeonsangjeon/kafka-metric-example/blob/master/docs/contracts/telemetry-event-v1.schema.json",
+  "$id": "https://github.com/hyeonsangjeon/foundry-stream-lab/blob/master/docs/contracts/telemetry-event-v1.schema.json",
   "title": "Foundry Stream Lab telemetry event v1",
   "description": "Privacy-safe lifecycle metadata published to Kafka. Raw AI payloads and infrastructure identifiers are forbidden by this contract.",
   "type": "object",

--- a/docs/demo-runbook.md
+++ b/docs/demo-runbook.md
@@ -193,9 +193,9 @@ Before deletion:
 1. Run the released application and capture its allowlisted comparison result:
 
    ```bash
-   export SOURCE_VERSION='v1.2.0'
-   export SOURCE_COMMIT="$(git rev-parse 'v1.2.0^{commit}')"
-   export SOURCE_ARTIFACT='ghcr.io/hyeonsangjeon/kafka-metric-example@sha256:RELEASE_DIGEST'
+   export SOURCE_VERSION='v1.3.0'
+   export SOURCE_COMMIT="$(git rev-parse 'v1.3.0^{commit}')"
+   export SOURCE_ARTIFACT='ghcr.io/hyeonsangjeon/foundry-stream-lab@sha256:RELEASE_DIGEST'
    ./tools/evidence/capture_comparison.sh \
      docs/evidence/YYYY-MM-DD-foundry-compare/data/application
    ```

--- a/docs/migration.md
+++ b/docs/migration.md
@@ -35,5 +35,9 @@ never accepted by the new core.
 
 The original dashboard was derived from the Apache Vert.x
 `vertx-examples/kafka-examples` project and included third-party UI assets. The
-rewrite carries forward the Apache-2.0 license and `NOTICE`, but copies none of
-the legacy JavaScript, Java source, templates, images, or fonts.
+2026 rewrite copies none of the legacy JavaScript, Java source, templates,
+images, or fonts. Project-authored files in the current tree are MIT-licensed;
+`NOTICE` and `LICENSES/Apache-2.0.txt` preserve the earlier lineage and terms.
+Historical revisions and releases through `v1.2.0` remain under the license
+that accompanied them, and all third-party dependencies retain their own
+licenses.

--- a/infra/README.md
+++ b/infra/README.md
@@ -50,14 +50,19 @@ currently selected `az` account; inspect and set it before `--apply`.
 All managed resources carry these tags:
 
 ```text
-application=kafka-metric-example
+application=foundry-stream-lab
 environment=demo
 managed-by=kafka-metric-example-infra
 purpose=model-router-demo
 cleanup=resource-group
-repository=kafka-metric-example
+repository=foundry-stream-lab
 expires-on=<UTC date seven days after provisioning>
 ```
+
+The `managed-by` value intentionally remains stable across the repository
+rename so existing demo resource groups can still pass the guarded cleanup
+check. New runs use `foundry-stream-lab` for the application and repository
+tags.
 
 Set `AZURE_EXPIRES_ON=YYYY-MM-DD` to override that advisory expiry tag. The tag
 does not schedule deletion; cleanup remains an explicit guarded operation.

--- a/infra/lib.sh
+++ b/infra/lib.sh
@@ -38,10 +38,12 @@ readonly ROUTER_MODEL_VERSION="2025-11-18"
 readonly MODEL_SKU="GlobalStandard"
 readonly MODEL_CAPACITY="10"
 
+# Keep this ownership sentinel stable so cleanup remains safe for resource
+# groups created before the repository was renamed to foundry-stream-lab.
 readonly MANAGED_BY_TAG="kafka-metric-example-infra"
 readonly LEGACY_MANAGED_BY_TAG="codex"
 readonly PURPOSE_TAG="model-router-demo"
-readonly REPOSITORY_TAG="${AZURE_REPOSITORY_TAG:-kafka-metric-example}"
+readonly REPOSITORY_TAG="${AZURE_REPOSITORY_TAG:-foundry-stream-lab}"
 readonly EXPIRES_ON_TAG="${AZURE_EXPIRES_ON:-$(default_expiry_date)}"
 readonly DEPLOYMENT_NAME="${AZURE_DEPLOYMENT_NAME:-kafka-router-demo-infra}"
 readonly ACCOUNT_API_VERSION="2026-03-01"

--- a/infra/provision.sh
+++ b/infra/provision.sh
@@ -146,7 +146,7 @@ if resource_group_exists; then
   az group update \
     --name "$RESOURCE_GROUP" \
     --tags \
-      application=kafka-metric-example \
+      application=foundry-stream-lab \
       environment=demo \
       managed-by="$MANAGED_BY_TAG" \
       purpose="$PURPOSE_TAG" \
@@ -161,7 +161,7 @@ else
     --name "$RESOURCE_GROUP" \
     --location "$LOCATION" \
     --tags \
-      application=kafka-metric-example \
+      application=foundry-stream-lab \
       environment=demo \
       managed-by="$MANAGED_BY_TAG" \
       purpose="$PURPOSE_TAG" \
@@ -246,7 +246,7 @@ tags_json="$(jq -cn \
   --arg purpose "$PURPOSE_TAG" \
   --arg repository "$REPOSITORY_TAG" \
   --arg expiresOn "$EXPIRES_ON_TAG" \
-  '{application:"kafka-metric-example",environment:"demo","managed-by":$managedBy,purpose:$purpose,cleanup:"resource-group",repository:$repository,"expires-on":$expiresOn}')"
+  '{application:"foundry-stream-lab",environment:"demo","managed-by":$managedBy,purpose:$purpose,cleanup:"resource-group",repository:$repository,"expires-on":$expiresOn}')"
 az deployment group create \
   --name "$DEPLOYMENT_NAME" \
   --resource-group "$RESOURCE_GROUP" \

--- a/tools/evidence/capture_comparison.sh
+++ b/tools/evidence/capture_comparison.sh
@@ -11,9 +11,9 @@ Usage:
 Optional environment:
   BASE_URL=http://127.0.0.1:8080
   EXPECTED_PROVIDER_MODE=foundry
-  SOURCE_VERSION=v1.2.0
+  SOURCE_VERSION=v1.3.0
   SOURCE_COMMIT=0123456789abcdef0123456789abcdef01234567
-  SOURCE_ARTIFACT=git:v1.2.0
+  SOURCE_ARTIFACT=git:v1.3.0
   COMPARISON_WORKLOAD=chat
   COMPARISON_SCENARIO=healthy
   COMPARISON_TRAFFIC=1
@@ -59,7 +59,7 @@ base_url="${base_url%/}"
   || die "EXPECTED_PROVIDER_MODE must be foundry or simulated"
 if [[ "$expected_provider_mode" == "foundry" ]]; then
   [[ "$source_version" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] \
-    || die "SOURCE_VERSION must be a release tag such as v1.2.0"
+    || die "SOURCE_VERSION must be a release tag such as v1.3.0"
   [[ "$source_commit" =~ ^[0-9a-f]{40}$ ]] \
     || die "SOURCE_COMMIT must be a full lowercase Git commit SHA"
   [[ "$source_artifact" =~ ^(git:v[0-9]+\.[0-9]+\.[0-9]+|ghcr\.io/[a-z0-9._/-]+@sha256:[0-9a-f]{64})$ ]] \

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -1,12 +1,13 @@
 {
   "name": "foundry-stream-lab-web",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "foundry-stream-lab-web",
-      "version": "1.2.0",
+      "version": "1.3.0",
+      "license": "MIT",
       "dependencies": {
         "lucide-react": "^1.24.0",
         "react": "^19.2.7",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,16 @@
 {
   "name": "foundry-stream-lab-web",
   "private": true,
-  "version": "1.2.0",
+  "version": "1.3.0",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/hyeonsangjeon/foundry-stream-lab.git"
+  },
+  "bugs": {
+    "url": "https://github.com/hyeonsangjeon/foundry-stream-lab/issues"
+  },
+  "homepage": "https://github.com/hyeonsangjeon/foundry-stream-lab#readme",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/web/src/components/AppShell.tsx
+++ b/web/src/components/AppShell.tsx
@@ -98,7 +98,7 @@ export function AppShell({
         <div className="sidebar__footer">
           <div className="privacy-mini"><ShieldCheck size={15} /><span>Payload bodies private</span></div>
           <div className="lab-running"><StatusDot status={connection} /><span>{connection === 'connected' ? 'Lab connected' : 'Lab offline'}</span></div>
-          <span className="version">v1.2.0</span>
+          <span className="version">v1.3.0</span>
         </div>
       </aside>
 


### PR DESCRIPTION
## Summary

- clarify the Foundry Stream Lab purpose and prepare repository references for the `foundry-stream-lab` rename
- license the rewritten current tree under MIT while preserving the historical Apache-2.0 text and complete runtime notices
- apply the five closed Dependabot updates as one maintainer-authored dependency refresh
- prevent routine Dependabot version PRs while retaining security alerts and security updates
- bump the new MIT release line to v1.3.0 and package legal metadata in the JAR and image

## Validation

- Java 21 `mvn clean verify`: 52 tests passed
- `npm ci`, lint, 30 tests, production build, and audit: passed; 0 vulnerabilities
- YAML, JSON, XML, shell, Compose, and diff validation: passed
- arm64 Docker build: passed; MIT labels and packaged notices verified
- standalone and Kafka Compose smoke runs: three-profile comparison completed with 3 provider invocations

## Follow-up after merge

- rename the GitHub repository to `hyeonsangjeon/foundry-stream-lab`
- publish v1.3.0 to the new GHCR package, make it public, and verify anonymous multi-platform pulls