### PR TITLE
Add rename-aware repository traffic attribution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,8 @@ jobs:
           python-version: "3.12"
       - name: Test evaluation wrapper
         run: python -m unittest discover -s tools/eval/tests -p 'test_*.py'
+      - name: Test GitHub traffic attribution
+        run: python -m unittest discover -s tools/github/tests -p 'test_*.py'
       - name: Validate offline evaluation inputs
         run: python tools/eval/eval.py validate
       - name: Validate infrastructure sources

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help demo stop kafka test backend-test web-test build java-check
+.PHONY: help demo stop kafka test backend-test web-test repository-traffic repository-traffic-test build java-check
 
 help: ## Show available commands
 	@awk 'BEGIN {FS = ":.*## "; printf "Foundry Stream Lab\n\n"} /^[a-zA-Z_-]+:.*## / {printf "  %-14s %s\n", $$1, $$2}' $(MAKEFILE_LIST)
@@ -29,6 +29,19 @@ web-test: ## Run frontend lint, tests, and production build
 	cd web && npm run lint && npm run test -- --run && npm run build
 
 test: backend-test web-test ## Run all checks
+
+repository-traffic: ## Capture and classify the rolling GitHub traffic window
+	mkdir -p tmp/repository-traffic
+	python3 tools/github/traffic_attribution.py \
+		--repository hyeonsangjeon/foundry-stream-lab \
+		--legacy-repository hyeonsangjeon/kafka-metric-example \
+		--renamed-at 2026-07-17T05:39:55Z \
+		--output-json tmp/repository-traffic/snapshot.json \
+		--output-markdown tmp/repository-traffic/summary.md
+	@cat tmp/repository-traffic/summary.md
+
+repository-traffic-test: ## Run offline GitHub traffic attribution tests
+	python3 -m unittest discover -s tools/github/tests -p 'test_*.py'
 
 build: ## Build the production container
 	docker build -t foundry-stream-lab:local .

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ requires the Azure CLI; the Docker quick start does not.
 make test          # Java tests, frontend lint/tests/build
 make backend-test  # Maven verify
 make web-test      # ESLint, Vitest, Vite production build
+make repository-traffic-test  # Offline GitHub traffic attribution tests
 make build         # Production container image
 ```
 
@@ -254,6 +255,7 @@ For credential-free host development, start the backend with
 app/                 Java 21 / Vert.x API, providers, transport, projection
 web/                 React / TypeScript dashboard
 docs/                Architecture, scenarios, Foundry setup, event contract
+tools/               Evaluation, evidence, Foundry, and repository utilities
 compose.yaml         Kafka KRaft broker, topics, and application
 Dockerfile           Reproducible multi-stage production image
 .github/workflows/   Backend, frontend, and container CI
@@ -288,6 +290,12 @@ demo. It keeps the useful `event -> Kafka -> projection -> live dashboard`
 idea while replacing the legacy Java/runtime path and vendored admin theme with
 a focused Microsoft Foundry routing, evaluation, and observability lab. See
 [the migration and provenance note](docs/migration.md).
+
+The rename also means GitHub's rolling traffic window can contain both the old
+and canonical repository paths. The
+[repository traffic attribution guide](docs/repository-traffic.md) defines the
+separate metrics and the repeatable capture workflow; legacy-path views are not
+treated as new-name content interest.
 
 ## License and provenance
 

--- a/docs/repository-traffic.md
+++ b/docs/repository-traffic.md
@@ -1,0 +1,116 @@
+# Repository traffic attribution
+
+GitHub repository traffic is a short operational signal, not a product
+analytics system. This repository was renamed from
+`hyeonsangjeon/kafka-metric-example` to
+`hyeonsangjeon/foundry-stream-lab` on 2026-07-17. GitHub redirects the old web
+paths, while the [Traffic API](https://docs.github.com/en/rest/metrics/traffic?apiVersion=2022-11-28)
+reports a rolling 14-day window and only the top 10 popular paths. A snapshot
+taken near the rename can therefore contain both slugs without representing
+traffic from two independent repositories. See GitHub's
+[repository rename behavior](https://docs.github.com/en/repositories/creating-and-managing-repositories/renaming-a-repository)
+for the redirect contract.
+
+Use [`tools/github/traffic_attribution.py`](../tools/github/traffic_attribution.py)
+to preserve the raw API response and classify each returned path. The tool does
+not modify repository settings, commit generated data, or sum unique visitors
+across paths.
+
+## Metric contract
+
+| Metric | Meaning |
+| --- | --- |
+| `total_views` | Complete view count returned by `/traffic/views` for GitHub's rolling window. |
+| `unique_visitors` | Window-level unique count from `/traffic/views`; this is the authoritative unique metric. |
+| `canonical_known_top_path_views` | Views among returned top paths whose exact repository prefix is `/hyeonsangjeon/foundry-stream-lab`. |
+| `legacy_known_top_path_views` | Views among returned top paths whose exact repository prefix is `/hyeonsangjeon/kafka-metric-example`. |
+| `other_known_top_path_views` | Views in returned top paths that belong to neither configured prefix. |
+| `not_in_top_paths_views` | `total_views` minus the sum of returned top paths; these views cannot be attributed by this API. |
+| `top_path_coverage` | Returned top-path views divided by `total_views`; `1.0` means the returned rows cover this snapshot, not that the endpoint is generally complete. |
+
+The `*_known_top_path_views` names are deliberate. Popular paths is capped at
+10 rows, so canonical and legacy counts can be lower bounds. Only when
+`not_in_top_paths_views` is zero does the path split cover the complete total
+for that snapshot.
+
+Path-level `uniques` are retained only as raw row metadata. The same visitor can
+appear on several paths, so those values must never be added together.
+
+## Rename transition baseline
+
+The snapshot captured at `2026-07-21T16:12:09Z` returned:
+
+- 11 total views from one unique visitor;
+- 9 legacy known-top-path views and 2 canonical known-top-path views;
+- zero views outside the five returned popular paths;
+- 10 views on 2026-07-17 UTC and 1 view on 2026-07-19 UTC;
+- `github.com` as the referrer for all 11 views.
+
+This does not support interpreting “11 views” as 11 users showing interest in
+the rebuilt content. It is a rename-attribution snapshot from one unique
+visitor. GitHub does not expose a path-by-date cross-tab, so the 2026-07-17
+views cannot be divided into pre-rename and post-redirect requests.
+
+The current README, workflows, container references, OCI source label, and Git
+remote use the canonical name. Remaining old-name strings are an intentional
+cleanup ownership sentinel or immutable historical evidence. Do not rewrite
+those records to make a rolling traffic report look cleaner.
+
+The audit also issued HTTP `HEAD` requests to old URLs after capturing the
+snapshot. GitHub does not document whether those probes count as views. Use a
+snapshot taken on or after 2026-08-06 KST as the first clean post-audit check.
+
+## Local capture
+
+The live path uses the authenticated GitHub CLI. It requires repository
+administration read access because that is the permission required by the
+Traffic API.
+
+```bash
+gh auth status
+make repository-traffic
+```
+
+The command writes ignored, ephemeral outputs to:
+
+- `tmp/repository-traffic/snapshot.json`
+- `tmp/repository-traffic/summary.md`
+
+Run only the transformation tests with:
+
+```bash
+make repository-traffic-test
+```
+
+For a fully offline reproduction, pass `--views-file`, `--paths-file`, and
+`--referrers-file` to the Python tool. See
+[`tools/github/README.md`](../tools/github/README.md) for the exact interface.
+
+## Automation boundary
+
+This public repository intentionally does not run the capture in GitHub
+Actions. The workflow `GITHUB_TOKEN` cannot receive the Traffic API's
+`Administration: read` permission, and supplying a separate token would make
+the otherwise administrator-only raw paths and referrers visible through a
+public run summary or artifact.
+
+Keep live snapshots local and ignored. If long-term automation becomes
+necessary, send the result to a separately reviewed private store using a
+GitHub App or fine-grained token limited to this repository and
+`Administration: Read-only`. Do not commit snapshots to `master`, copy a broad
+local OAuth token into Actions, or publish raw referrers merely to retain a
+history.
+
+## Interpretation rules
+
+- Report total, canonical-known, legacy-known, other-known, and unattributed
+  views separately.
+- Exclude rename-ambiguous totals from claims about interest in the canonical
+  content.
+- Treat a continuing legacy count after the clean-check date as redirect
+  traffic, then inspect releases and external backlinks without changing
+  historical evidence.
+- Treat canonical-known views as confirmed canonical-path traffic, not as a
+  user count and not automatically as positive engagement.
+- Keep the raw snapshot with every published interpretation so the top-path
+  coverage and unique denominator remain auditable.

--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -1,0 +1,54 @@
+# GitHub repository utilities
+
+`traffic_attribution.py` captures the three private repository Traffic API
+surfaces needed to distinguish canonical, legacy, other, and unattributed page
+views:
+
+- `/traffic/views`
+- `/traffic/popular/paths`
+- `/traffic/popular/referrers`
+
+It depends only on Python's standard library and the authenticated `gh` CLI.
+It never prints or persists an authentication token.
+
+## Live capture
+
+```bash
+python3 tools/github/traffic_attribution.py \
+  --repository hyeonsangjeon/foundry-stream-lab \
+  --legacy-repository hyeonsangjeon/kafka-metric-example \
+  --renamed-at 2026-07-17T05:39:55Z \
+  --output-json tmp/repository-traffic/snapshot.json \
+  --output-markdown tmp/repository-traffic/summary.md
+```
+
+`--repository` is both the API target and canonical path prefix. Repeat
+`--legacy-repository` if more than one historical slug must be classified.
+`--renamed-at` controls whether the rolling UTC window is marked rename
+ambiguous.
+
+## Offline analysis
+
+Saved API responses can be analyzed without network access:
+
+```bash
+python3 tools/github/traffic_attribution.py \
+  --repository hyeonsangjeon/foundry-stream-lab \
+  --legacy-repository hyeonsangjeon/kafka-metric-example \
+  --renamed-at 2026-07-17T05:39:55Z \
+  --views-file /path/to/views.json \
+  --paths-file /path/to/paths.json \
+  --referrers-file /path/to/referrers.json \
+  --output-json /tmp/traffic.json \
+  --output-markdown /tmp/traffic.md
+```
+
+All three offline files are required together. JSON output contains the raw
+responses, classification rows, metric definitions, window metadata, and
+limitations. Markdown is a compact operator summary of the same snapshot.
+
+## Tests
+
+```bash
+python3 -m unittest discover -s tools/github/tests -p 'test_*.py'
+```

--- a/tools/github/tests/test_traffic_attribution.py
+++ b/tools/github/tests/test_traffic_attribution.py
@@ -1,0 +1,357 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import tempfile
+import unittest
+from datetime import datetime
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SPEC = importlib.util.spec_from_file_location(
+    "github_traffic_attribution", ROOT / "traffic_attribution.py"
+)
+assert SPEC and SPEC.loader
+TRAFFIC = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(TRAFFIC)
+
+
+def utc(value: str) -> datetime:
+    return TRAFFIC.parse_timestamp(value, field="test timestamp")
+
+
+def views_payload(*, count: int = 11, uniques: int = 1) -> dict:
+    daily = []
+    for day in range(7, 21):
+        daily.append(
+            {
+                "timestamp": f"2026-07-{day:02d}T00:00:00Z",
+                "count": 10 if day == 17 else 1 if day == 19 else 0,
+                "uniques": 1 if day in {17, 19} else 0,
+            }
+        )
+    return {"count": count, "uniques": uniques, "views": daily}
+
+
+def current_paths() -> list[dict]:
+    return [
+        {
+            "path": "/hyeonsangjeon/kafka-metric-example",
+            "title": "Overview",
+            "count": 4,
+            "uniques": 1,
+        },
+        {
+            "path": "/hyeonsangjeon/foundry-stream-lab",
+            "title": "Overview",
+            "count": 2,
+            "uniques": 1,
+        },
+        {
+            "path": (
+                "/hyeonsangjeon/kafka-metric-example/blob/master/docs/design/"
+                "compare-run-simulator-desktop.jpg"
+            ),
+            "title": "/blob/master/docs/design/compare-run-simulator-desktop.jpg",
+            "count": 2,
+            "uniques": 1,
+        },
+        {
+            "path": "/hyeonsangjeon/kafka-metric-example/pulls",
+            "title": "/pulls",
+            "count": 2,
+            "uniques": 1,
+        },
+        {
+            "path": "/hyeonsangjeon/kafka-metric-example/releases/tag/v1.2.0",
+            "title": "/releases/tag/v1.2.0",
+            "count": 1,
+            "uniques": 1,
+        },
+    ]
+
+
+def build(**overrides):
+    arguments = {
+        "repository": "hyeonsangjeon/foundry-stream-lab",
+        "legacy_repositories": ["hyeonsangjeon/kafka-metric-example"],
+        "renamed_at": utc("2026-07-17T05:39:55Z"),
+        "now": utc("2026-07-21T16:12:09Z"),
+        "views_payload": views_payload(),
+        "paths_payload": current_paths(),
+        "referrers_payload": [{"referrer": "github.com", "count": 11, "uniques": 1}],
+    }
+    arguments.update(overrides)
+    return TRAFFIC.build_report(**arguments)
+
+
+class TrafficAttributionTests(unittest.TestCase):
+    def test_current_snapshot_splits_nine_legacy_and_two_canonical_views(self):
+        report = build()
+
+        self.assertEqual(report["totals"]["views"], 11)
+        self.assertEqual(report["totals"]["uniqueVisitors"], 1)
+        self.assertEqual(report["pathAttribution"]["groups"]["legacy"]["views"], 9)
+        self.assertEqual(report["pathAttribution"]["groups"]["canonical"]["views"], 2)
+        self.assertEqual(
+            report["pathAttribution"]["groups"]["legacy"]["shareOfTotalPercent"], 81.8
+        )
+        self.assertEqual(report["pathAttribution"]["coveragePercent"], 100.0)
+        self.assertEqual(report["pathAttribution"]["unattributedViews"], 0)
+        self.assertEqual(report["metrics"]["top_path_coverage"], 1.0)
+        self.assertEqual(report["metrics"]["legacy_known_top_path_views"], 9)
+        self.assertEqual(report["rawResponses"]["views"]["count"], 11)
+        self.assertIn("total_views", report["metricDefinitions"])
+        self.assertEqual(report["interpretation"]["status"], "rename-window-ambiguous")
+        self.assertFalse(report["interpretation"]["contentInterestInferred"])
+        self.assertFalse(
+            report["interpretation"][
+                "totalRepositoryViewsFullyAttributedToCanonicalPaths"
+            ]
+        )
+
+    def test_repository_matching_requires_an_exact_path_boundary(self):
+        paths = [
+            {
+                "path": "/hyeonsangjeon/kafka-metric-example-copy",
+                "title": "Prefix collision",
+                "count": 3,
+                "uniques": 2,
+            },
+            {
+                "path": "/HYEONSANGJEON/FOUNDRY-STREAM-LAB/issues",
+                "title": "Canonical case variant",
+                "count": 2,
+                "uniques": 1,
+            },
+        ]
+        payload = {"count": 5, "uniques": 2, "views": []}
+        report = build(views_payload=payload, paths_payload=paths)
+
+        self.assertEqual(report["pathAttribution"]["groups"]["other"]["views"], 3)
+        self.assertEqual(report["pathAttribution"]["groups"]["canonical"]["views"], 2)
+        self.assertTrue(
+            TRAFFIC.repository_path_matches(
+                "/hyeonsangjeon/kafka-metric-example/pulls",
+                "hyeonsangjeon/kafka-metric-example",
+            )
+        )
+        self.assertFalse(
+            TRAFFIC.repository_path_matches(
+                "/hyeonsangjeon/kafka-metric-example-copy",
+                "hyeonsangjeon/kafka-metric-example",
+            )
+        )
+
+    def test_top_ten_shortfall_is_reported_as_unattributed_not_canonical(self):
+        report = build(
+            views_payload=views_payload(count=20), paths_payload=current_paths()
+        )
+
+        attribution = report["pathAttribution"]
+        self.assertEqual(attribution["listedViews"], 11)
+        self.assertEqual(attribution["unattributedViews"], 9)
+        self.assertEqual(attribution["coveragePercent"], 55.0)
+        self.assertEqual(attribution["coverageStatus"], "partial")
+        self.assertFalse(attribution["coverageComplete"])
+
+    def test_path_uniques_are_preserved_but_never_summed_into_a_group(self):
+        report = build()
+        attribution = report["pathAttribution"]
+
+        self.assertFalse(attribution["uniqueVisitorsAdditiveAcrossPaths"])
+        self.assertEqual(report["totals"]["uniqueVisitorAuthority"], "views.uniques")
+        self.assertNotIn("uniqueVisitors", attribution["groups"]["legacy"])
+        self.assertEqual(sum(row["uniqueVisitors"] for row in attribution["paths"]), 5)
+        self.assertEqual(report["totals"]["uniqueVisitors"], 1)
+
+    def test_legacy_paths_after_window_receive_a_distinct_status(self):
+        daily = [
+            {"timestamp": "2026-08-07T00:00:00Z", "count": 1, "uniques": 1},
+            {"timestamp": "2026-08-08T00:00:00Z", "count": 0, "uniques": 0},
+        ]
+        report = build(
+            now=utc("2026-08-09T00:00:00Z"),
+            views_payload={"count": 1, "uniques": 1, "views": daily},
+            paths_payload=[current_paths()[0] | {"count": 1}],
+            referrers_payload=[],
+        )
+
+        self.assertFalse(report["window"]["windowOverlapsRename"])
+        self.assertEqual(report["window"]["renameRelation"], "post-rename")
+        self.assertEqual(
+            report["interpretation"]["status"], "legacy-paths-after-rename-window"
+        )
+
+    def test_pre_rename_window_is_not_described_as_post_rename_legacy_traffic(self):
+        daily = [
+            {"timestamp": "2026-07-01T00:00:00Z", "count": 1, "uniques": 1},
+            {"timestamp": "2026-07-02T00:00:00Z", "count": 0, "uniques": 0},
+        ]
+        report = build(
+            views_payload={"count": 1, "uniques": 1, "views": daily},
+            paths_payload=[current_paths()[0] | {"count": 1}],
+            referrers_payload=[],
+        )
+
+        self.assertEqual(report["window"]["renameRelation"], "pre-rename")
+        self.assertEqual(report["interpretation"]["status"], "pre-rename-window")
+        self.assertIn("historical repository traffic", TRAFFIC.render_markdown(report))
+
+    def test_complete_canonical_paths_are_attributed_without_inferring_interest(self):
+        paths = [
+            {
+                "path": "/hyeonsangjeon/foundry-stream-lab",
+                "title": "Overview",
+                "count": 11,
+                "uniques": 1,
+            }
+        ]
+        report = build(paths_payload=paths)
+
+        self.assertEqual(report["interpretation"]["status"], "canonical-only")
+        self.assertEqual(report["window"]["renameRelation"], "overlaps-rename")
+        self.assertTrue(
+            report["interpretation"][
+                "totalRepositoryViewsFullyAttributedToCanonicalPaths"
+            ]
+        )
+        self.assertFalse(report["interpretation"]["contentInterestInferred"])
+        self.assertNotIn("outside the rename", TRAFFIC.render_markdown(report))
+
+    def test_cli_rejects_a_future_rename_timestamp(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            with self.assertRaisesRegex(
+                TRAFFIC.TrafficAttributionError, "must not be later"
+            ):
+                TRAFFIC.main(
+                    [
+                        "--repository",
+                        "hyeonsangjeon/foundry-stream-lab",
+                        "--legacy-repository",
+                        "hyeonsangjeon/kafka-metric-example",
+                        "--renamed-at",
+                        "2026-07-22T00:00:01Z",
+                        "--now",
+                        "2026-07-22T00:00:00Z",
+                        "--output-json",
+                        str(root / "out.json"),
+                        "--output-markdown",
+                        str(root / "out.md"),
+                    ]
+                )
+
+    def test_json_and_markdown_rendering_are_deterministic(self):
+        report = build()
+
+        self.assertEqual(TRAFFIC.render_json(report), TRAFFIC.render_json(report))
+        self.assertEqual(
+            TRAFFIC.render_markdown(report), TRAFFIC.render_markdown(report)
+        )
+        parsed = json.loads(TRAFFIC.render_json(report))
+        self.assertEqual(parsed, report)
+        markdown = TRAFFIC.render_markdown(report)
+        self.assertIn("**rename-window-ambiguous**", markdown)
+        self.assertIn("Path-level unique counts overlap", markdown)
+        self.assertTrue(markdown.endswith("\n"))
+
+    def test_offline_cli_writes_stable_json_and_markdown(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            inputs = {
+                "views.json": views_payload(),
+                "paths.json": current_paths(),
+                "referrers.json": [
+                    {"referrer": "github.com", "count": 11, "uniques": 1}
+                ],
+            }
+            for name, payload in inputs.items():
+                (root / name).write_text(json.dumps(payload), encoding="utf-8")
+            output_json = root / "out" / "traffic.json"
+            output_markdown = root / "out" / "traffic.md"
+            arguments = [
+                "--repository",
+                "hyeonsangjeon/foundry-stream-lab",
+                "--legacy-repository",
+                "hyeonsangjeon/kafka-metric-example",
+                "--renamed-at",
+                "2026-07-17T05:39:55Z",
+                "--now",
+                "2026-07-21T16:12:09Z",
+                "--views-file",
+                str(root / "views.json"),
+                "--paths-file",
+                str(root / "paths.json"),
+                "--referrers-file",
+                str(root / "referrers.json"),
+                "--output-json",
+                str(output_json),
+                "--output-markdown",
+                str(output_markdown),
+            ]
+
+            self.assertEqual(TRAFFIC.main(arguments), 0)
+            first_json = output_json.read_bytes()
+            first_markdown = output_markdown.read_bytes()
+            self.assertEqual(TRAFFIC.main(arguments), 0)
+            self.assertEqual(output_json.read_bytes(), first_json)
+            self.assertEqual(output_markdown.read_bytes(), first_markdown)
+            self.assertEqual(json.loads(first_json)["schemaVersion"], 1)
+
+    def test_live_collection_uses_three_versioned_gh_api_requests(self):
+        responses = [
+            subprocess.CompletedProcess([], 0, json.dumps(views_payload()), ""),
+            subprocess.CompletedProcess([], 0, json.dumps(current_paths()), ""),
+            subprocess.CompletedProcess(
+                [],
+                0,
+                json.dumps([{"referrer": "github.com", "count": 11, "uniques": 1}]),
+                "",
+            ),
+        ]
+        with mock.patch.object(TRAFFIC.subprocess, "run", side_effect=responses) as run:
+            views, paths, referrers = TRAFFIC.collect_live(
+                "hyeonsangjeon/foundry-stream-lab"
+            )
+
+        self.assertEqual(views["count"], 11)
+        self.assertEqual(len(paths), 5)
+        self.assertEqual(referrers[0]["referrer"], "github.com")
+        self.assertEqual(run.call_count, 3)
+        commands = [call.args[0] for call in run.call_args_list]
+        self.assertTrue(commands[0][-1].endswith("/traffic/views"))
+        self.assertTrue(commands[1][-1].endswith("/traffic/popular/paths"))
+        self.assertTrue(commands[2][-1].endswith("/traffic/popular/referrers"))
+        self.assertIn(f"X-GitHub-Api-Version: {TRAFFIC.API_VERSION}", commands[0])
+
+    def test_partial_offline_input_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "views.json").write_text("{}", encoding="utf-8")
+            with self.assertRaisesRegex(
+                TRAFFIC.TrafficAttributionError, "must be provided together"
+            ):
+                TRAFFIC.main(
+                    [
+                        "--repository",
+                        "hyeonsangjeon/foundry-stream-lab",
+                        "--legacy-repository",
+                        "hyeonsangjeon/kafka-metric-example",
+                        "--renamed-at",
+                        "2026-07-17T05:39:55Z",
+                        "--views-file",
+                        str(root / "views.json"),
+                        "--output-json",
+                        str(root / "out.json"),
+                        "--output-markdown",
+                        str(root / "out.md"),
+                    ]
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/github/traffic_attribution.py
+++ b/tools/github/traffic_attribution.py
@@ -1,0 +1,717 @@
+#!/usr/bin/env python3
+"""Capture and classify GitHub repository traffic across a repository rename."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+from collections.abc import Mapping, Sequence
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any
+
+
+API_VERSION = "2022-11-28"
+POPULAR_PATH_LIMIT = 10
+ROLLING_WINDOW_DAYS = 14
+_REPOSITORY_RE = re.compile(r"^[A-Za-z0-9.-]+/[A-Za-z0-9_.-]+$")
+
+
+class TrafficAttributionError(RuntimeError):
+    """Raised when traffic inputs cannot be collected or safely interpreted."""
+
+
+def parse_timestamp(value: str, *, field: str) -> datetime:
+    if not isinstance(value, str) or not value.strip():
+        raise TrafficAttributionError(f"{field} must be a non-empty ISO-8601 timestamp")
+    normalized = value.strip()
+    if normalized.endswith("Z"):
+        normalized = f"{normalized[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(normalized)
+    except ValueError as exc:
+        raise TrafficAttributionError(
+            f"{field} is not a valid ISO-8601 timestamp: {value}"
+        ) from exc
+    if parsed.tzinfo is None:
+        raise TrafficAttributionError(f"{field} must include a UTC offset")
+    return parsed.astimezone(timezone.utc)
+
+
+def format_timestamp(value: datetime) -> str:
+    return (
+        value.astimezone(timezone.utc)
+        .replace(microsecond=0)
+        .isoformat()
+        .replace("+00:00", "Z")
+    )
+
+
+def normalize_repository(value: str, *, field: str) -> str:
+    if not isinstance(value, str) or not _REPOSITORY_RE.fullmatch(value):
+        raise TrafficAttributionError(f"{field} must have the form OWNER/REPOSITORY")
+    return value
+
+
+def _require_mapping(value: Any, *, field: str) -> Mapping[str, Any]:
+    if not isinstance(value, Mapping):
+        raise TrafficAttributionError(f"{field} must be a JSON object")
+    return value
+
+
+def _require_list(value: Any, *, field: str) -> list[Any]:
+    if not isinstance(value, list):
+        raise TrafficAttributionError(f"{field} must be a JSON array")
+    return value
+
+
+def _non_negative_integer(value: Any, *, field: str) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise TrafficAttributionError(f"{field} must be a non-negative integer")
+    return value
+
+
+def _string(value: Any, *, field: str) -> str:
+    if not isinstance(value, str):
+        raise TrafficAttributionError(f"{field} must be a string")
+    return value
+
+
+def _read_json(path: Path, *, field: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise TrafficAttributionError(f"{field} does not exist: {path}") from exc
+    except OSError as exc:
+        raise TrafficAttributionError(
+            f"could not read {field} at {path}: {exc}"
+        ) from exc
+    except json.JSONDecodeError as exc:
+        raise TrafficAttributionError(f"{field} is not valid JSON: {exc}") from exc
+
+
+def _gh_api(endpoint: str) -> Any:
+    command = [
+        "gh",
+        "api",
+        "--method",
+        "GET",
+        "-H",
+        "Accept: application/vnd.github+json",
+        "-H",
+        f"X-GitHub-Api-Version: {API_VERSION}",
+        endpoint,
+    ]
+    try:
+        completed = subprocess.run(
+            command,
+            check=False,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=30,
+        )
+    except FileNotFoundError as exc:
+        raise TrafficAttributionError(
+            "GitHub CLI (gh) is required for live collection"
+        ) from exc
+    except subprocess.TimeoutExpired as exc:
+        raise TrafficAttributionError(
+            f"GitHub API request timed out: {endpoint}"
+        ) from exc
+    if completed.returncode != 0:
+        detail = completed.stderr.strip() or f"exit status {completed.returncode}"
+        raise TrafficAttributionError(
+            f"GitHub API request failed for {endpoint}: {detail}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise TrafficAttributionError(
+            f"GitHub API returned invalid JSON for {endpoint}"
+        ) from exc
+
+
+def collect_live(repository: str) -> tuple[Any, Any, Any]:
+    base = f"repos/{repository}/traffic"
+    return (
+        _gh_api(f"{base}/views"),
+        _gh_api(f"{base}/popular/paths"),
+        _gh_api(f"{base}/popular/referrers"),
+    )
+
+
+def repository_path_matches(path: str, repository: str) -> bool:
+    """Match one GitHub repository path without accepting prefix collisions."""
+
+    prefix = f"/{repository}".casefold()
+    candidate = path.casefold()
+    return candidate == prefix or candidate.startswith(f"{prefix}/")
+
+
+def classify_path(path: str, canonical: str, legacy: Sequence[str]) -> str:
+    if repository_path_matches(path, canonical):
+        return "canonical"
+    if any(repository_path_matches(path, repository) for repository in legacy):
+        return "legacy"
+    return "other"
+
+
+def _normalize_daily_views(views_payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    daily_payload = _require_list(views_payload.get("views"), field="views.views")
+    daily: list[dict[str, Any]] = []
+    seen_timestamps: set[str] = set()
+    for index, raw_row in enumerate(daily_payload):
+        row = _require_mapping(raw_row, field=f"views.views[{index}]")
+        parsed = parse_timestamp(
+            _string(row.get("timestamp"), field=f"views.views[{index}].timestamp"),
+            field=f"views.views[{index}].timestamp",
+        )
+        timestamp = format_timestamp(parsed)
+        if timestamp in seen_timestamps:
+            raise TrafficAttributionError(
+                f"views.views contains duplicate timestamp {timestamp}"
+            )
+        seen_timestamps.add(timestamp)
+        daily.append(
+            {
+                "timestamp": timestamp,
+                "views": _non_negative_integer(
+                    row.get("count"), field=f"views.views[{index}].count"
+                ),
+                "uniqueVisitors": _non_negative_integer(
+                    row.get("uniques"), field=f"views.views[{index}].uniques"
+                ),
+            }
+        )
+    return sorted(daily, key=lambda row: row["timestamp"])
+
+
+def _normalize_paths(
+    paths_payload: Any,
+    *,
+    canonical: str,
+    legacy: Sequence[str],
+) -> list[dict[str, Any]]:
+    rows = _require_list(paths_payload, field="popular paths")
+    normalized: list[dict[str, Any]] = []
+    seen_paths: set[str] = set()
+    for index, raw_row in enumerate(rows):
+        row = _require_mapping(raw_row, field=f"popular paths[{index}]")
+        path = _string(row.get("path"), field=f"popular paths[{index}].path")
+        if not path.startswith("/"):
+            raise TrafficAttributionError(
+                f"popular paths[{index}].path must start with /"
+            )
+        dedupe_key = path.casefold()
+        if dedupe_key in seen_paths:
+            raise TrafficAttributionError(
+                f"popular paths contains duplicate path {path}"
+            )
+        seen_paths.add(dedupe_key)
+        normalized.append(
+            {
+                "attribution": classify_path(path, canonical, legacy),
+                "path": path,
+                "title": _string(
+                    row.get("title"), field=f"popular paths[{index}].title"
+                ),
+                "views": _non_negative_integer(
+                    row.get("count"), field=f"popular paths[{index}].count"
+                ),
+                "uniqueVisitors": _non_negative_integer(
+                    row.get("uniques"), field=f"popular paths[{index}].uniques"
+                ),
+            }
+        )
+    normalized.sort(
+        key=lambda row: (-row["views"], row["path"].casefold(), row["title"].casefold())
+    )
+    return normalized
+
+
+def _normalize_referrers(referrers_payload: Any) -> list[dict[str, Any]]:
+    rows = _require_list(referrers_payload, field="popular referrers")
+    normalized: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw_row in enumerate(rows):
+        row = _require_mapping(raw_row, field=f"popular referrers[{index}]")
+        referrer = _string(
+            row.get("referrer"), field=f"popular referrers[{index}].referrer"
+        )
+        dedupe_key = referrer.casefold()
+        if dedupe_key in seen:
+            raise TrafficAttributionError(
+                f"popular referrers contains duplicate referrer {referrer}"
+            )
+        seen.add(dedupe_key)
+        normalized.append(
+            {
+                "referrer": referrer,
+                "views": _non_negative_integer(
+                    row.get("count"), field=f"popular referrers[{index}].count"
+                ),
+                "uniqueVisitors": _non_negative_integer(
+                    row.get("uniques"), field=f"popular referrers[{index}].uniques"
+                ),
+            }
+        )
+    normalized.sort(key=lambda row: (-row["views"], row["referrer"].casefold()))
+    return normalized
+
+
+def _window(
+    daily_views: Sequence[Mapping[str, Any]], *, now: datetime, renamed_at: datetime
+) -> dict[str, Any]:
+    if daily_views:
+        dates = [
+            parse_timestamp(row["timestamp"], field="daily timestamp").date()
+            for row in daily_views
+        ]
+        start_date = min(dates)
+        end_date = max(dates)
+        source = "observed-daily-buckets"
+    else:
+        end_date = now.date()
+        start_date = end_date - timedelta(days=ROLLING_WINDOW_DAYS - 1)
+        source = "inferred-from-analysis-time"
+    rename_date = renamed_at.date()
+    if end_date < rename_date:
+        rename_relation = "pre-rename"
+    elif start_date <= rename_date <= end_date:
+        rename_relation = "overlaps-rename"
+    else:
+        rename_relation = "post-rename"
+    return {
+        "days": ROLLING_WINDOW_DAYS,
+        "endDateUtc": end_date.isoformat(),
+        "observedDailyBuckets": len(daily_views),
+        "renameRelation": rename_relation,
+        "source": source,
+        "startDateUtc": start_date.isoformat(),
+        "type": "rolling",
+        "windowOverlapsRename": rename_relation == "overlaps-rename",
+    }
+
+
+def _percentage(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return 0.0 if numerator == 0 else None
+    return round(100.0 * numerator / denominator, 1)
+
+
+def _ratio(numerator: int, denominator: int) -> float | None:
+    if denominator == 0:
+        return 1.0 if numerator == 0 else None
+    return round(numerator / denominator, 4)
+
+
+def build_report(
+    *,
+    repository: str,
+    legacy_repositories: Sequence[str],
+    renamed_at: datetime,
+    now: datetime,
+    views_payload: Any,
+    paths_payload: Any,
+    referrers_payload: Any,
+) -> dict[str, Any]:
+    canonical = normalize_repository(repository, field="repository")
+    if renamed_at > now:
+        raise TrafficAttributionError(
+            "renamed-at must not be later than the analysis timestamp"
+        )
+    legacy = [
+        normalize_repository(value, field="legacy repository")
+        for value in legacy_repositories
+    ]
+    deduplicated_legacy: list[str] = []
+    seen_repositories = {canonical.casefold()}
+    for value in legacy:
+        if value.casefold() in seen_repositories:
+            raise TrafficAttributionError(
+                "canonical and legacy repositories must be distinct and non-duplicated"
+            )
+        seen_repositories.add(value.casefold())
+        deduplicated_legacy.append(value)
+    if not deduplicated_legacy:
+        raise TrafficAttributionError("at least one legacy repository is required")
+
+    views = _require_mapping(views_payload, field="views")
+    total_views = _non_negative_integer(views.get("count"), field="views.count")
+    total_uniques = _non_negative_integer(views.get("uniques"), field="views.uniques")
+    daily_views = _normalize_daily_views(views)
+    paths = _normalize_paths(
+        paths_payload, canonical=canonical, legacy=deduplicated_legacy
+    )
+    referrers = _normalize_referrers(referrers_payload)
+
+    listed_views = sum(row["views"] for row in paths)
+    group_views = {
+        group: sum(row["views"] for row in paths if row["attribution"] == group)
+        for group in ("canonical", "legacy", "other")
+    }
+    groups = {
+        group: {
+            "shareOfListedPercent": _percentage(count, listed_views),
+            "shareOfTotalPercent": _percentage(count, total_views),
+            "views": count,
+        }
+        for group, count in group_views.items()
+    }
+    unattributed_views = max(total_views - listed_views, 0)
+    over_attributed_views = max(listed_views - total_views, 0)
+    if listed_views == total_views:
+        coverage_status = "exact"
+    elif listed_views < total_views:
+        coverage_status = "partial"
+    else:
+        coverage_status = "over-total"
+
+    window = _window(daily_views, now=now, renamed_at=renamed_at)
+    fully_canonical = (
+        group_views["legacy"] == 0
+        and group_views["other"] == 0
+        and unattributed_views == 0
+        and over_attributed_views == 0
+    )
+    if window["renameRelation"] == "pre-rename":
+        status = "pre-rename-window"
+    elif fully_canonical:
+        status = "canonical-only"
+    elif window["windowOverlapsRename"]:
+        status = "rename-window-ambiguous"
+    elif group_views["legacy"] > 0:
+        status = "legacy-paths-after-rename-window"
+    elif group_views["other"] > 0 or coverage_status != "exact":
+        status = "incomplete-path-attribution"
+    else:
+        status = "canonical-only"
+
+    daily_sum = sum(row["views"] for row in daily_views)
+
+    return {
+        "analyzedAt": format_timestamp(now),
+        "apiVersion": API_VERSION,
+        "interpretation": {
+            "canonicalKnownTopPathViews": group_views["canonical"],
+            "contentInterestInferred": False,
+            "pathByDateAvailable": False,
+            "status": status,
+            "totalRepositoryViewsFullyAttributedToCanonicalPaths": fully_canonical,
+        },
+        "limitations": [
+            "popular paths returns at most 10 rows",
+            "path-level unique visitors overlap and are not additive",
+            "GitHub does not expose path-by-date traffic",
+            "rename-day views cannot be split into pre-rename and redirect traffic",
+        ],
+        "metricDefinitions": {
+            "canonical_known_top_path_views": (
+                "views in returned popular paths matching the canonical repository boundary"
+            ),
+            "legacy_known_top_path_views": (
+                "views in returned popular paths matching a legacy repository boundary"
+            ),
+            "not_in_top_paths_views": (
+                "total repository views minus views covered by returned popular paths"
+            ),
+            "other_known_top_path_views": (
+                "views in returned popular paths matching neither canonical nor legacy boundaries"
+            ),
+            "top_path_coverage": "returned popular-path views divided by total repository views",
+            "total_views": "rolling repository view count from traffic/views",
+            "unique_visitors": "authoritative rolling unique count from traffic/views uniques",
+        },
+        "metrics": {
+            "canonical_known_top_path_views": group_views["canonical"],
+            "legacy_known_top_path_views": group_views["legacy"],
+            "not_in_top_paths_views": unattributed_views,
+            "other_known_top_path_views": group_views["other"],
+            "top_path_coverage": _ratio(listed_views, total_views),
+            "total_views": total_views,
+            "unique_visitors": total_uniques,
+        },
+        "pathAttribution": {
+            "coverageComplete": coverage_status == "exact",
+            "coveragePercent": _percentage(listed_views, total_views),
+            "coverageStatus": coverage_status,
+            "groups": groups,
+            "listedViews": listed_views,
+            "overAttributedViews": over_attributed_views,
+            "pathRowsMayBeTruncated": len(paths) >= POPULAR_PATH_LIMIT,
+            "paths": paths,
+            "rowLimit": POPULAR_PATH_LIMIT,
+            "scope": "github-popular-paths",
+            "unattributedViews": unattributed_views,
+            "uniqueVisitorsAdditiveAcrossPaths": False,
+        },
+        "referrers": referrers,
+        "rawResponses": {
+            "popularPaths": paths_payload,
+            "popularReferrers": referrers_payload,
+            "views": views_payload,
+        },
+        "rename": {
+            "legacyRepositories": deduplicated_legacy,
+            "renamedAt": format_timestamp(renamed_at),
+        },
+        "repository": canonical,
+        "schemaVersion": 1,
+        "totals": {
+            "dailyViewsMatchTotal": daily_sum == total_views,
+            "dailyViewsSum": daily_sum,
+            "uniqueVisitorAuthority": "views.uniques",
+            "uniqueVisitors": total_uniques,
+            "views": total_views,
+        },
+        "viewsByDay": daily_views,
+        "window": window,
+    }
+
+
+def render_json(report: Mapping[str, Any]) -> str:
+    return json.dumps(report, ensure_ascii=False, indent=2, sort_keys=True) + "\n"
+
+
+def _markdown_cell(value: Any) -> str:
+    return str(value).replace("\\", "\\\\").replace("|", "\\|").replace("\n", " ")
+
+
+def _percent(value: float | None) -> str:
+    return "n/a" if value is None else f"{value:.1f}%"
+
+
+def _decision_text(status: str) -> str:
+    return {
+        "pre-rename-window": (
+            "The observed traffic window ends before the configured rename. Treat it as "
+            "historical repository traffic, not canonical-name content interest."
+        ),
+        "rename-window-ambiguous": (
+            "The rolling window overlaps the rename. Total repository views must not be "
+            "interpreted as canonical content interest because GitHub does not expose a "
+            "path-by-date cross-tab."
+        ),
+        "legacy-paths-after-rename-window": (
+            "Legacy paths remain after the rename window. Treat them as redirect or stale-link "
+            "traffic and investigate backlinks separately."
+        ),
+        "incomplete-path-attribution": (
+            "Popular paths do not fully and exclusively attribute the total. Keep canonical, "
+            "legacy, other, and unattributed views separate."
+        ),
+        "canonical-only": (
+            "Every repository view in this snapshot is covered by canonical popular paths. "
+            "This is path attribution only and does not infer content interest."
+        ),
+    }[status]
+
+
+def render_markdown(report: Mapping[str, Any]) -> str:
+    totals = report["totals"]
+    attribution = report["pathAttribution"]
+    window = report["window"]
+    rename = report["rename"]
+    interpretation = report["interpretation"]
+    groups = attribution["groups"]
+    lines = [
+        "# GitHub traffic attribution",
+        "",
+        f"Repository: `{report['repository']}`  ",
+        f"Analyzed at: `{report['analyzedAt']}`  ",
+        f"Rename: `{', '.join(rename['legacyRepositories'])}` → `{report['repository']}` at "
+        f"`{rename['renamedAt']}`",
+        "",
+        "## Decision",
+        "",
+        f"**{interpretation['status']}** — {_decision_text(interpretation['status'])}",
+        "",
+        "## Summary",
+        "",
+        "| Metric | Value |",
+        "| --- | ---: |",
+        f"| Total repository views | {totals['views']} |",
+        f"| Overall unique visitors | {totals['uniqueVisitors']} |",
+        f"| Canonical popular-path views | {groups['canonical']['views']} |",
+        f"| Legacy popular-path views | {groups['legacy']['views']} |",
+        f"| Other popular-path views | {groups['other']['views']} |",
+        f"| Unattributed views outside returned popular paths | {attribution['unattributedViews']} |",
+        f"| Popular-path coverage | {_percent(attribution['coveragePercent'])} |",
+        "",
+        "Overall unique visitors come only from `views.uniques`. Path-level unique counts "
+        "overlap and are intentionally not summed.",
+        "",
+        "## Popular paths",
+        "",
+        "| Attribution | Path | Title | Views | Path uniques |",
+        "| --- | --- | --- | ---: | ---: |",
+    ]
+    if attribution["paths"]:
+        for row in attribution["paths"]:
+            lines.append(
+                "| {attribution} | {path} | {title} | {views} | {uniques} |".format(
+                    attribution=_markdown_cell(row["attribution"]),
+                    path=_markdown_cell(row["path"]),
+                    title=_markdown_cell(row["title"]),
+                    views=row["views"],
+                    uniques=row["uniqueVisitors"],
+                )
+            )
+    else:
+        lines.append("| — | — | — | 0 | 0 |")
+
+    lines.extend(
+        [
+            "",
+            f"GitHub returns at most {attribution['rowLimit']} popular paths. Coverage is "
+            f"`{attribution['coverageStatus']}`; a full top-10 response may still be truncated.",
+            "",
+            "## Rename window",
+            "",
+            f"- Rolling window: `{window['startDateUtc']}` through `{window['endDateUtc']}` UTC",
+            f"- Rename relation: `{window['renameRelation']}`",
+            f"- Window overlaps rename: `{'yes' if window['windowOverlapsRename'] else 'no'}`",
+            "- Path-by-date attribution: unavailable from the GitHub Traffic API",
+            "",
+            "## Popular referrers",
+            "",
+            "| Referrer | Views | Referrer uniques |",
+            "| --- | ---: | ---: |",
+        ]
+    )
+    if report["referrers"]:
+        for row in report["referrers"]:
+            lines.append(
+                f"| {_markdown_cell(row['referrer'])} | {row['views']} | "
+                f"{row['uniqueVisitors']} |"
+            )
+    else:
+        lines.append("| — | 0 | 0 |")
+    lines.extend(
+        [
+            "",
+            "## Interpretation constraints",
+            "",
+            "- `views` is the rolling repository total; it is not automatically a content-interest KPI.",
+            "- Canonical, legacy, and other counts cover only the popular paths returned by GitHub.",
+            "- Path-level unique counts are non-additive; use the overall unique visitor count above.",
+            "- A rename-day view cannot be split into pre-rename and post-redirect traffic.",
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def _atomic_write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    descriptor, temporary_name = tempfile.mkstemp(
+        prefix=f".{path.name}.", dir=str(path.parent), text=True
+    )
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8", newline="\n") as handle:
+            handle.write(content)
+        os.replace(temporary_name, path)
+    finally:
+        try:
+            os.unlink(temporary_name)
+        except FileNotFoundError:
+            pass
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Classify GitHub traffic across canonical and renamed repository paths."
+    )
+    parser.add_argument(
+        "--repository", required=True, help="Canonical OWNER/REPOSITORY"
+    )
+    parser.add_argument(
+        "--legacy-repository",
+        action="append",
+        required=True,
+        help="Legacy OWNER/REPOSITORY; repeat for multiple old names",
+    )
+    parser.add_argument(
+        "--renamed-at", required=True, help="Rename timestamp with UTC offset"
+    )
+    parser.add_argument("--output-json", required=True, type=Path)
+    parser.add_argument("--output-markdown", required=True, type=Path)
+    parser.add_argument(
+        "--views-file", type=Path, help="Offline raw traffic/views JSON"
+    )
+    parser.add_argument(
+        "--paths-file", type=Path, help="Offline raw traffic/popular/paths JSON"
+    )
+    parser.add_argument(
+        "--referrers-file", type=Path, help="Offline raw traffic/popular/referrers JSON"
+    )
+    parser.add_argument(
+        "--now",
+        help="Analysis timestamp with UTC offset; freeze this for deterministic offline output",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    repository = normalize_repository(args.repository, field="repository")
+    renamed_at = parse_timestamp(args.renamed_at, field="renamed-at")
+    now = (
+        parse_timestamp(args.now, field="now")
+        if args.now
+        else datetime.now(timezone.utc)
+    )
+    if renamed_at > now:
+        raise TrafficAttributionError(
+            "renamed-at must not be later than the analysis timestamp"
+        )
+    offline_paths = [args.views_file, args.paths_file, args.referrers_file]
+    if any(path is not None for path in offline_paths) and not all(
+        path is not None for path in offline_paths
+    ):
+        raise TrafficAttributionError(
+            "--views-file, --paths-file, and --referrers-file must be provided together"
+        )
+    output_paths = {args.output_json.resolve(), args.output_markdown.resolve()}
+    if len(output_paths) != 2:
+        raise TrafficAttributionError(
+            "JSON and Markdown outputs must use different paths"
+        )
+    if all(path is not None for path in offline_paths):
+        input_paths = {path.resolve() for path in offline_paths}
+        if output_paths & input_paths:
+            raise TrafficAttributionError(
+                "output paths must not overwrite offline input files"
+            )
+        views_payload = _read_json(args.views_file, field="views file")
+        paths_payload = _read_json(args.paths_file, field="paths file")
+        referrers_payload = _read_json(args.referrers_file, field="referrers file")
+    else:
+        views_payload, paths_payload, referrers_payload = collect_live(repository)
+
+    report = build_report(
+        repository=repository,
+        legacy_repositories=args.legacy_repository,
+        renamed_at=renamed_at,
+        now=now,
+        views_payload=views_payload,
+        paths_payload=paths_payload,
+        referrers_payload=referrers_payload,
+    )
+    _atomic_write(args.output_json, render_json(report))
+    _atomic_write(args.output_markdown, render_markdown(report))
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except TrafficAttributionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        raise SystemExit(2) from exc


### PR DESCRIPTION
## Summary

- add a standard-library GitHub Traffic capture and attribution CLI
- split total, canonical-known, legacy-known, other-known, and unattributed views
- preserve raw API responses while keeping path-level unique counts non-additive
- document the rename window, local-only data boundary, and clean recheck policy
- run 12 offline attribution tests in the existing tooling CI job

## Why

The rolling 14-day Traffic API window currently mixes the former kafka-metric-example path with the canonical foundry-stream-lab path. Treating all 11 views as canonical content interest overstates the signal and hides the rename boundary.

Live capture remains local because publishing administrator-only paths and referrers through a public Actions run would weaken the data boundary.

## Impact

Maintainers can run make repository-traffic for an auditable JSON and Markdown snapshot. Generated data stays under ignored tmp storage and no application runtime behavior changes.

## Checks

- 12 GitHub traffic attribution unit tests
- authenticated live capture: total 11, unique 1, canonical 2, legacy 9, coverage 100%
- evaluation tooling tests and offline validation
- frontend lint, 30 tests, and production build
- backend Maven verify on Java 21: 52 tests
- Dockerfile build check
- ruff check and format check
- independent security and correctness review: no findings