### PR TITLE
extend repository traffic attribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,12 +30,13 @@ web-test: ## Run frontend lint, tests, and production build
 
 test: backend-test web-test ## Run all checks
 
-repository-traffic: ## Capture and classify the rolling GitHub traffic window
+repository-traffic: ## Capture views, clones, and rename attribution
 	mkdir -p tmp/repository-traffic
 	python3 tools/github/traffic_attribution.py \
 		--repository hyeonsangjeon/foundry-stream-lab \
 		--legacy-repository hyeonsangjeon/kafka-metric-example \
 		--renamed-at 2026-07-17T05:39:55Z \
+		--archive-directory tmp/repository-traffic/archive \
 		--output-json tmp/repository-traffic/snapshot.json \
 		--output-markdown tmp/repository-traffic/summary.md
 	@cat tmp/repository-traffic/summary.md

--- a/README.md
+++ b/README.md
@@ -294,8 +294,8 @@ a focused Microsoft Foundry routing, evaluation, and observability lab. See
 The rename also means GitHub's rolling traffic window can contain both the old
 and canonical repository paths. The
 [repository traffic attribution guide](docs/repository-traffic.md) defines the
-separate metrics and the repeatable capture workflow; legacy-path views are not
-treated as new-name content interest.
+separate metrics and the repeatable capture workflow; legacy-path views and
+repository-level clone totals are not treated as new-name content interest.
 
 ## License and provenance
 

--- a/docs/repository-traffic.md
+++ b/docs/repository-traffic.md
@@ -27,6 +27,8 @@ across paths.
 | `other_known_top_path_views` | Views in returned top paths that belong to neither configured prefix. |
 | `not_in_top_paths_views` | `total_views` minus the sum of returned top paths; these views cannot be attributed by this API. |
 | `top_path_coverage` | Returned top-path views divided by `total_views`; `1.0` means the returned rows cover this snapshot, not that the endpoint is generally complete. |
+| `total_clones` | Complete full-clone count returned by `/traffic/clones` for GitHub's rolling 14-day window; fetches are excluded. |
+| `unique_cloners` | Window-level unique count from `/traffic/clones`; daily unique-cloner values must not be added. |
 
 The `*_known_top_path_views` names are deliberate. Popular paths is capped at
 10 rows, so canonical and legacy counts can be lower bounds. Only when
@@ -35,6 +37,11 @@ for that snapshot.
 
 Path-level `uniques` are retained only as raw row metadata. The same visitor can
 appear on several paths, so those values must never be added together.
+
+Clone totals have no equivalent path attribution. The clones endpoint returns
+only repository-level totals and UTC daily buckets; it does not expose whether
+the requested remote used the canonical or legacy repository slug. Never apply
+the popular-path 9:3 view ratio to clones.
 
 ## Rename transition baseline
 
@@ -49,7 +56,7 @@ The snapshot captured at `2026-07-21T16:12:09Z` returned:
 This does not support interpreting “11 views” as 11 users showing interest in
 the rebuilt content. It is a rename-attribution snapshot from one unique
 visitor. GitHub does not expose a path-by-date cross-tab, so the 2026-07-17
-views cannot be divided into pre-rename and post-redirect requests.
+views cannot be divided into pre-rename and post-rename requests.
 
 The current README, workflows, container references, OCI source label, and Git
 remote use the canonical name. Remaining old-name strings are an intentional
@@ -59,6 +66,52 @@ those records to make a rolling traffic report look cleaner.
 The audit also issued HTTP `HEAD` requests to old URLs after capturing the
 snapshot. GitHub does not document whether those probes count as views. Use a
 snapshot taken on or after 2026-08-06 KST as the first clean post-audit check.
+
+## Operational checkpoint: 2026-07-30
+
+The incoming high-priority signal reported 7-day views of 12, 14-day clones of
+331, 9 legacy-path views, 3 canonical Overview views with 1 path unique, and
+`github.com` as the 12-view referrer. That signal did not include a capture
+timestamp or the source of its 7-day view rollup. Preserve it as an upstream
+observation rather than joining it directly to the 14-day popular-path and
+referrer tables.
+
+A live API capture at `2026-07-30T14:46:05Z` verified the following native
+rolling 14-day snapshot for `2026-07-16` through `2026-07-29` UTC:
+
+| Signal | Count | Unique value and scope | Slug attribution |
+| --- | ---: | ---: | --- |
+| Repository views | 12 | 1 window-level visitor | canonical 3 · legacy 9 · other 0 · unattributed 0 |
+| Canonical Overview popular path | 3 | 1 path unique; non-additive | canonical |
+| Full clones | 332 | 109 window-level cloners | unavailable |
+| `github.com` referrer | 12 | 1 referrer unique | cannot be joined to a path or clone |
+
+The one-clone difference from the incoming 331 is consistent with rolling-window
+snapshot drift; the verified response includes one clone in the 2026-07-29 UTC
+bucket. Capture time and window must accompany every reported total.
+
+The ignored private evidence is archived at
+`tmp/repository-traffic/archive/2026-07-30T144605Z/`. Its SHA-256 checksums are:
+
+- `snapshot.json`:
+  `b49ee648ab4ba4537cad7e0cd6a8c5d5094831064875ee5d47b0c4e24749faa8`
+- `summary.md`:
+  `7012bfd2b4e10acae78974fdce60cd3342e9ee633e2c65ca5e2f52b8ef89f69a`
+
+Repository identity resolution and traffic labels are separate concerns:
+
+- Repository API lookups for both slugs resolved to repository ID `176433281`
+  with canonical `full_name` `hyeonsangjeon/foundry-stream-lab`.
+- `git ls-remote` against both old and new clone URLs returned the same HEAD,
+  `248d943b7d6029d4c5b3a8a25916c6d24e8adb5f`.
+- The canonical Traffic API still returned 9 views labelled with legacy paths
+  and 3 views labelled with the canonical path.
+- The clone response contains no requested URL or slug, so its 332 full clones
+  cannot be divided into legacy and canonical clone demand.
+
+The operating status therefore remains `rename-window-ambiguous`. Keep this
+high item open until the clean snapshot on or after 2026-08-06 KST confirms
+whether legacy path labels persist outside the audit and rename windows.
 
 ## Local capture
 
@@ -71,10 +124,15 @@ gh auth status
 make repository-traffic
 ```
 
-The command writes ignored, ephemeral outputs to:
+The command writes ignored latest outputs to:
 
 - `tmp/repository-traffic/snapshot.json`
 - `tmp/repository-traffic/summary.md`
+
+It also writes an immutable timestamped private evidence set to
+`tmp/repository-traffic/archive/<UTC timestamp>/`, containing `snapshot.json`,
+`summary.md`, and `checksums.sha256`. Repeating the same timestamp with
+different content fails instead of overwriting evidence.
 
 Run only the transformation tests with:
 
@@ -82,8 +140,10 @@ Run only the transformation tests with:
 make repository-traffic-test
 ```
 
-For a fully offline reproduction, pass `--views-file`, `--paths-file`, and
-`--referrers-file` to the Python tool. See
+For a fully offline reproduction, also pass `--clones-file` with
+`--views-file`, `--paths-file`, and `--referrers-file`. Existing three-file
+offline inputs remain supported, but clone fields are explicitly marked
+unavailable. See
 [`tools/github/README.md`](../tools/github/README.md) for the exact interface.
 
 ## Automation boundary
@@ -107,10 +167,13 @@ history.
   views separately.
 - Exclude rename-ambiguous totals from claims about interest in the canonical
   content.
-- Treat a continuing legacy count after the clean-check date as redirect
-  traffic, then inspect releases and external backlinks without changing
-  historical evidence.
+- Treat a continuing legacy count after the clean-check date as
+  `legacy-labelled / mapping-unverified`. Inspect releases and external
+  backlinks without claiming redirect demand or changing historical evidence.
 - Treat canonical-known views as confirmed canonical-path traffic, not as a
   user count and not automatically as positive engagement.
+- Report clone totals as repository-level full clones only. Do not infer
+  canonical-name demand or distribute clones using popular-path shares.
 - Keep the raw snapshot with every published interpretation so the top-path
-  coverage and unique denominator remain auditable.
+  coverage, clone availability, capture time, and unique denominators remain
+  auditable.

--- a/tools/github/README.md
+++ b/tools/github/README.md
@@ -1,10 +1,11 @@
 # GitHub repository utilities
 
-`traffic_attribution.py` captures the three private repository Traffic API
-surfaces needed to distinguish canonical, legacy, other, and unattributed page
-views:
+`traffic_attribution.py` captures four private repository Traffic API surfaces.
+Popular paths distinguish canonical, legacy, other, and unattributed page
+views, while clones remain a separate repository-level aggregate:
 
 - `/traffic/views`
+- `/traffic/clones`
 - `/traffic/popular/paths`
 - `/traffic/popular/referrers`
 
@@ -18,6 +19,7 @@ python3 tools/github/traffic_attribution.py \
   --repository hyeonsangjeon/foundry-stream-lab \
   --legacy-repository hyeonsangjeon/kafka-metric-example \
   --renamed-at 2026-07-17T05:39:55Z \
+  --archive-directory tmp/repository-traffic/archive \
   --output-json tmp/repository-traffic/snapshot.json \
   --output-markdown tmp/repository-traffic/summary.md
 ```
@@ -25,7 +27,9 @@ python3 tools/github/traffic_attribution.py \
 `--repository` is both the API target and canonical path prefix. Repeat
 `--legacy-repository` if more than one historical slug must be classified.
 `--renamed-at` controls whether the rolling UTC window is marked rename
-ambiguous.
+ambiguous. `--archive-directory` preserves an immutable timestamped copy of the
+JSON, Markdown, and SHA-256 checksums while the fixed output paths remain the
+latest snapshot.
 
 ## Offline analysis
 
@@ -37,15 +41,23 @@ python3 tools/github/traffic_attribution.py \
   --legacy-repository hyeonsangjeon/kafka-metric-example \
   --renamed-at 2026-07-17T05:39:55Z \
   --views-file /path/to/views.json \
+  --clones-file /path/to/clones.json \
   --paths-file /path/to/paths.json \
   --referrers-file /path/to/referrers.json \
   --output-json /tmp/traffic.json \
   --output-markdown /tmp/traffic.md
 ```
 
-All three offline files are required together. JSON output contains the raw
-responses, classification rows, metric definitions, window metadata, and
-limitations. Markdown is a compact operator summary of the same snapshot.
+Views, paths, and referrers are required together. `--clones-file` is optional
+only for compatibility with snapshots captured before schema version 2; when
+omitted, clone fields are `null` and source availability is `false`. JSON output
+contains the raw responses, classification rows, metric definitions, window
+metadata, and limitations. Markdown is a compact operator summary of the same
+snapshot.
+
+GitHub does not return the clone URL used by a client. The report therefore
+keeps full-clone totals and unique cloners at repository scope and never
+allocates them using canonical/legacy popular-path shares.
 
 ## Tests
 

--- a/tools/github/tests/test_traffic_attribution.py
+++ b/tools/github/tests/test_traffic_attribution.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import hashlib
 import importlib.util
 import json
 import subprocess
 import tempfile
 import unittest
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime
 from pathlib import Path
 from unittest import mock
@@ -74,6 +76,36 @@ def current_paths() -> list[dict]:
     ]
 
 
+def followup_paths() -> list[dict]:
+    paths = current_paths()
+    paths[1] = paths[1] | {"count": 3}
+    return paths
+
+
+def clones_payload(*, count: int = 332, uniques: int = 109) -> dict:
+    return {
+        "count": count,
+        "uniques": uniques,
+        "clones": [
+            {
+                "timestamp": "2026-07-16T00:00:00Z",
+                "count": 99,
+                "uniques": 30,
+            },
+            {
+                "timestamp": "2026-07-17T00:00:00Z",
+                "count": 177,
+                "uniques": 56,
+            },
+            {
+                "timestamp": "2026-07-18T00:00:00Z",
+                "count": 56,
+                "uniques": 40,
+            },
+        ],
+    }
+
+
 def build(**overrides):
     arguments = {
         "repository": "hyeonsangjeon/foundry-stream-lab",
@@ -81,6 +113,7 @@ def build(**overrides):
         "renamed_at": utc("2026-07-17T05:39:55Z"),
         "now": utc("2026-07-21T16:12:09Z"),
         "views_payload": views_payload(),
+        "clones_payload": clones_payload(),
         "paths_payload": current_paths(),
         "referrers_payload": [{"referrer": "github.com", "count": 11, "uniques": 1}],
     }
@@ -104,6 +137,7 @@ class TrafficAttributionTests(unittest.TestCase):
         self.assertEqual(report["metrics"]["top_path_coverage"], 1.0)
         self.assertEqual(report["metrics"]["legacy_known_top_path_views"], 9)
         self.assertEqual(report["rawResponses"]["views"]["count"], 11)
+        self.assertEqual(report["rawResponses"]["clones"]["count"], 332)
         self.assertIn("total_views", report["metricDefinitions"])
         self.assertEqual(report["interpretation"]["status"], "rename-window-ambiguous")
         self.assertFalse(report["interpretation"]["contentInterestInferred"])
@@ -112,6 +146,21 @@ class TrafficAttributionTests(unittest.TestCase):
                 "totalRepositoryViewsFullyAttributedToCanonicalPaths"
             ]
         )
+        self.assertFalse(report["interpretation"]["cloneDemandInferred"])
+        self.assertFalse(report["interpretation"]["cloneSlugAttributionAvailable"])
+
+    def test_followup_snapshot_splits_nine_legacy_and_three_canonical_views(self):
+        report = build(
+            views_payload=views_payload(count=12),
+            paths_payload=followup_paths(),
+            referrers_payload=[{"referrer": "github.com", "count": 12, "uniques": 1}],
+        )
+
+        self.assertEqual(report["metrics"]["total_views"], 12)
+        self.assertEqual(report["metrics"]["canonical_known_top_path_views"], 3)
+        self.assertEqual(report["metrics"]["legacy_known_top_path_views"], 9)
+        self.assertEqual(report["metrics"]["not_in_top_paths_views"], 0)
+        self.assertEqual(report["referrers"][0]["views"], 12)
 
     def test_repository_matching_requires_an_exact_path_boundary(self):
         paths = [
@@ -167,6 +216,69 @@ class TrafficAttributionTests(unittest.TestCase):
         self.assertNotIn("uniqueVisitors", attribution["groups"]["legacy"])
         self.assertEqual(sum(row["uniqueVisitors"] for row in attribution["paths"]), 5)
         self.assertEqual(report["totals"]["uniqueVisitors"], 1)
+
+    def test_clone_totals_are_preserved_without_slug_attribution(self):
+        report = build()
+        clone_traffic = report["cloneTraffic"]
+
+        self.assertTrue(clone_traffic["available"])
+        self.assertEqual(clone_traffic["clones"], 332)
+        self.assertEqual(clone_traffic["uniqueCloners"], 109)
+        self.assertEqual(clone_traffic["dailyClonesSum"], 332)
+        self.assertTrue(clone_traffic["dailyClonesMatchTotal"])
+        self.assertFalse(clone_traffic["dailyUniqueClonersAdditive"])
+        self.assertFalse(clone_traffic["slugAttributionAvailable"])
+        self.assertFalse(clone_traffic["requestedRepositorySlugAvailable"])
+        self.assertEqual(
+            clone_traffic["dateRelationCounts"],
+            {
+                "preRenameDateClones": 99,
+                "renameDateClones": 177,
+                "postRenameDateClones": 56,
+            },
+        )
+        self.assertEqual(report["metrics"]["total_clones"], 332)
+        self.assertEqual(report["metrics"]["unique_cloners"], 109)
+        self.assertIn(
+            "Canonical/legacy clone attribution", TRAFFIC.render_markdown(report)
+        )
+
+    def test_clone_daily_total_mismatch_is_reported_without_rejection(self):
+        report = build(clones_payload=clones_payload(count=333))
+
+        self.assertEqual(report["cloneTraffic"]["dailyClonesSum"], 332)
+        self.assertFalse(report["cloneTraffic"]["dailyClonesMatchTotal"])
+        self.assertIn(
+            "Daily clone buckets sum to `332`, but the endpoint total is `333`",
+            TRAFFIC.render_markdown(report),
+        )
+
+    def test_duplicate_clone_timestamp_is_rejected(self):
+        payload = clones_payload()
+        payload["clones"].append(payload["clones"][0])
+
+        with self.assertRaisesRegex(
+            TRAFFIC.TrafficAttributionError, "duplicate timestamp"
+        ):
+            build(clones_payload=payload)
+
+    def test_invalid_clone_count_is_rejected(self):
+        payload = clones_payload()
+        payload["clones"][0]["count"] = True
+
+        with self.assertRaisesRegex(
+            TRAFFIC.TrafficAttributionError, "must be a non-negative integer"
+        ):
+            build(clones_payload=payload)
+
+    def test_invalid_clone_timestamp_is_rejected(self):
+        payload = clones_payload()
+        payload["clones"][0]["timestamp"] = "not-a-timestamp"
+
+        with self.assertRaisesRegex(
+            TRAFFIC.TrafficAttributionError, "not a valid ISO-8601 timestamp"
+        ):
+            build(clones_payload=payload)
 
     def test_legacy_paths_after_window_receive_a_distinct_status(self):
         daily = [
@@ -264,6 +376,7 @@ class TrafficAttributionTests(unittest.TestCase):
             root = Path(directory)
             inputs = {
                 "views.json": views_payload(),
+                "clones.json": clones_payload(),
                 "paths.json": current_paths(),
                 "referrers.json": [
                     {"referrer": "github.com", "count": 11, "uniques": 1}
@@ -273,6 +386,7 @@ class TrafficAttributionTests(unittest.TestCase):
                 (root / name).write_text(json.dumps(payload), encoding="utf-8")
             output_json = root / "out" / "traffic.json"
             output_markdown = root / "out" / "traffic.md"
+            archive_root = root / "archive"
             arguments = [
                 "--repository",
                 "hyeonsangjeon/foundry-stream-lab",
@@ -284,6 +398,8 @@ class TrafficAttributionTests(unittest.TestCase):
                 "2026-07-21T16:12:09Z",
                 "--views-file",
                 str(root / "views.json"),
+                "--clones-file",
+                str(root / "clones.json"),
                 "--paths-file",
                 str(root / "paths.json"),
                 "--referrers-file",
@@ -292,6 +408,8 @@ class TrafficAttributionTests(unittest.TestCase):
                 str(output_json),
                 "--output-markdown",
                 str(output_markdown),
+                "--archive-directory",
+                str(archive_root),
             ]
 
             self.assertEqual(TRAFFIC.main(arguments), 0)
@@ -300,11 +418,142 @@ class TrafficAttributionTests(unittest.TestCase):
             self.assertEqual(TRAFFIC.main(arguments), 0)
             self.assertEqual(output_json.read_bytes(), first_json)
             self.assertEqual(output_markdown.read_bytes(), first_markdown)
-            self.assertEqual(json.loads(first_json)["schemaVersion"], 1)
+            self.assertEqual(json.loads(first_json)["schemaVersion"], 2)
+            archive = archive_root / "2026-07-21T161209Z"
+            self.assertEqual((archive / "snapshot.json").read_bytes(), first_json)
+            self.assertEqual((archive / "summary.md").read_bytes(), first_markdown)
+            expected_checksums = (
+                f"{hashlib.sha256(first_json).hexdigest()}  snapshot.json\n"
+                f"{hashlib.sha256(first_markdown).hexdigest()}  summary.md\n"
+            )
+            self.assertEqual(
+                (archive / "checksums.sha256").read_text(encoding="utf-8"),
+                expected_checksums,
+            )
 
-    def test_live_collection_uses_three_versioned_gh_api_requests(self):
+    def test_three_file_offline_mode_remains_compatible_without_clone_data(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            inputs = {
+                "views.json": views_payload(),
+                "paths.json": current_paths(),
+                "referrers.json": [
+                    {"referrer": "github.com", "count": 11, "uniques": 1}
+                ],
+            }
+            for name, payload in inputs.items():
+                (root / name).write_text(json.dumps(payload), encoding="utf-8")
+            output_json = root / "traffic.json"
+            output_markdown = root / "traffic.md"
+
+            self.assertEqual(
+                TRAFFIC.main(
+                    [
+                        "--repository",
+                        "hyeonsangjeon/foundry-stream-lab",
+                        "--legacy-repository",
+                        "hyeonsangjeon/kafka-metric-example",
+                        "--renamed-at",
+                        "2026-07-17T05:39:55Z",
+                        "--now",
+                        "2026-07-21T16:12:09Z",
+                        "--views-file",
+                        str(root / "views.json"),
+                        "--paths-file",
+                        str(root / "paths.json"),
+                        "--referrers-file",
+                        str(root / "referrers.json"),
+                        "--output-json",
+                        str(output_json),
+                        "--output-markdown",
+                        str(output_markdown),
+                    ]
+                ),
+                0,
+            )
+
+            report = json.loads(output_json.read_text(encoding="utf-8"))
+            self.assertFalse(report["sourceAvailability"]["clones"])
+            self.assertIsNone(report["metrics"]["total_clones"])
+            self.assertIn(
+                "Clone input was not supplied",
+                output_markdown.read_text(encoding="utf-8"),
+            )
+
+    def test_archive_timestamp_is_immutable(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            report = build()
+            TRAFFIC._archive_report(
+                root,
+                report,
+                json_content=TRAFFIC.render_json(report),
+                markdown_content=TRAFFIC.render_markdown(report),
+            )
+            changed = build(views_payload=views_payload(count=12))
+
+            with self.assertRaisesRegex(
+                TRAFFIC.TrafficAttributionError,
+                "archive file already exists with different content",
+            ):
+                TRAFFIC._archive_report(
+                    root,
+                    changed,
+                    json_content=TRAFFIC.render_json(changed),
+                    markdown_content=TRAFFIC.render_markdown(changed),
+                )
+
+    def test_concurrent_archive_collision_never_mixes_evidence_sets(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            reports = [
+                build(),
+                build(views_payload=views_payload(count=12)),
+            ]
+
+            def publish(report):
+                try:
+                    return (
+                        "ok",
+                        TRAFFIC._archive_report(
+                            root,
+                            report,
+                            json_content=TRAFFIC.render_json(report),
+                            markdown_content=TRAFFIC.render_markdown(report),
+                        ),
+                    )
+                except TRAFFIC.TrafficAttributionError as exc:
+                    return ("error", str(exc))
+
+            with ThreadPoolExecutor(max_workers=2) as executor:
+                results = list(executor.map(publish, reports))
+
+            self.assertEqual([status for status, _ in results].count("ok"), 1)
+            self.assertEqual([status for status, _ in results].count("error"), 1)
+            destination = root / "2026-07-21T161209Z"
+            archived_pair = (
+                (destination / "snapshot.json").read_text(encoding="utf-8"),
+                (destination / "summary.md").read_text(encoding="utf-8"),
+            )
+            expected_pairs = {
+                (TRAFFIC.render_json(report), TRAFFIC.render_markdown(report))
+                for report in reports
+            }
+            self.assertIn(archived_pair, expected_pairs)
+            checksums = (destination / "checksums.sha256").read_text(encoding="utf-8")
+            self.assertEqual(
+                checksums,
+                f"{hashlib.sha256(archived_pair[0].encode()).hexdigest()}  snapshot.json\n"
+                f"{hashlib.sha256(archived_pair[1].encode()).hexdigest()}  summary.md\n",
+            )
+            self.assertEqual(
+                [path for path in root.iterdir() if path.name.startswith(".")], []
+            )
+
+    def test_live_collection_uses_four_versioned_gh_api_requests(self):
         responses = [
             subprocess.CompletedProcess([], 0, json.dumps(views_payload()), ""),
+            subprocess.CompletedProcess([], 0, json.dumps(clones_payload()), ""),
             subprocess.CompletedProcess([], 0, json.dumps(current_paths()), ""),
             subprocess.CompletedProcess(
                 [],
@@ -314,18 +563,20 @@ class TrafficAttributionTests(unittest.TestCase):
             ),
         ]
         with mock.patch.object(TRAFFIC.subprocess, "run", side_effect=responses) as run:
-            views, paths, referrers = TRAFFIC.collect_live(
+            views, clones, paths, referrers = TRAFFIC.collect_live(
                 "hyeonsangjeon/foundry-stream-lab"
             )
 
         self.assertEqual(views["count"], 11)
+        self.assertEqual(clones["count"], 332)
         self.assertEqual(len(paths), 5)
         self.assertEqual(referrers[0]["referrer"], "github.com")
-        self.assertEqual(run.call_count, 3)
+        self.assertEqual(run.call_count, 4)
         commands = [call.args[0] for call in run.call_args_list]
         self.assertTrue(commands[0][-1].endswith("/traffic/views"))
-        self.assertTrue(commands[1][-1].endswith("/traffic/popular/paths"))
-        self.assertTrue(commands[2][-1].endswith("/traffic/popular/referrers"))
+        self.assertTrue(commands[1][-1].endswith("/traffic/clones"))
+        self.assertTrue(commands[2][-1].endswith("/traffic/popular/paths"))
+        self.assertTrue(commands[3][-1].endswith("/traffic/popular/referrers"))
         self.assertIn(f"X-GitHub-Api-Version: {TRAFFIC.API_VERSION}", commands[0])
 
     def test_partial_offline_input_is_rejected(self):
@@ -347,6 +598,70 @@ class TrafficAttributionTests(unittest.TestCase):
                         str(root / "views.json"),
                         "--output-json",
                         str(root / "out.json"),
+                        "--output-markdown",
+                        str(root / "out.md"),
+                    ]
+                )
+
+    def test_clones_only_offline_input_is_rejected(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            (root / "clones.json").write_text(
+                json.dumps(clones_payload()), encoding="utf-8"
+            )
+            with self.assertRaisesRegex(
+                TRAFFIC.TrafficAttributionError, "--clones-file requires"
+            ):
+                TRAFFIC.main(
+                    [
+                        "--repository",
+                        "hyeonsangjeon/foundry-stream-lab",
+                        "--legacy-repository",
+                        "hyeonsangjeon/kafka-metric-example",
+                        "--renamed-at",
+                        "2026-07-17T05:39:55Z",
+                        "--clones-file",
+                        str(root / "clones.json"),
+                        "--output-json",
+                        str(root / "out.json"),
+                        "--output-markdown",
+                        str(root / "out.md"),
+                    ]
+                )
+
+    def test_output_cannot_overwrite_clone_input(self):
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            inputs = {
+                "views.json": views_payload(),
+                "clones.json": clones_payload(),
+                "paths.json": current_paths(),
+                "referrers.json": [],
+            }
+            for name, payload in inputs.items():
+                (root / name).write_text(json.dumps(payload), encoding="utf-8")
+            with self.assertRaisesRegex(
+                TRAFFIC.TrafficAttributionError,
+                "output paths must not overwrite offline input files",
+            ):
+                TRAFFIC.main(
+                    [
+                        "--repository",
+                        "hyeonsangjeon/foundry-stream-lab",
+                        "--legacy-repository",
+                        "hyeonsangjeon/kafka-metric-example",
+                        "--renamed-at",
+                        "2026-07-17T05:39:55Z",
+                        "--views-file",
+                        str(root / "views.json"),
+                        "--clones-file",
+                        str(root / "clones.json"),
+                        "--paths-file",
+                        str(root / "paths.json"),
+                        "--referrers-file",
+                        str(root / "referrers.json"),
+                        "--output-json",
+                        str(root / "clones.json"),
                         "--output-markdown",
                         str(root / "out.md"),
                     ]

--- a/tools/github/traffic_attribution.py
+++ b/tools/github/traffic_attribution.py
@@ -4,9 +4,11 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -137,10 +139,11 @@ def _gh_api(endpoint: str) -> Any:
         ) from exc
 
 
-def collect_live(repository: str) -> tuple[Any, Any, Any]:
+def collect_live(repository: str) -> tuple[Any, Any, Any, Any]:
     base = f"repos/{repository}/traffic"
     return (
         _gh_api(f"{base}/views"),
+        _gh_api(f"{base}/clones"),
         _gh_api(f"{base}/popular/paths"),
         _gh_api(f"{base}/popular/referrers"),
     )
@@ -186,6 +189,36 @@ def _normalize_daily_views(views_payload: Mapping[str, Any]) -> list[dict[str, A
                 ),
                 "uniqueVisitors": _non_negative_integer(
                     row.get("uniques"), field=f"views.views[{index}].uniques"
+                ),
+            }
+        )
+    return sorted(daily, key=lambda row: row["timestamp"])
+
+
+def _normalize_daily_clones(clones_payload: Mapping[str, Any]) -> list[dict[str, Any]]:
+    daily_payload = _require_list(clones_payload.get("clones"), field="clones.clones")
+    daily: list[dict[str, Any]] = []
+    seen_timestamps: set[str] = set()
+    for index, raw_row in enumerate(daily_payload):
+        row = _require_mapping(raw_row, field=f"clones.clones[{index}]")
+        parsed = parse_timestamp(
+            _string(row.get("timestamp"), field=f"clones.clones[{index}].timestamp"),
+            field=f"clones.clones[{index}].timestamp",
+        )
+        timestamp = format_timestamp(parsed)
+        if timestamp in seen_timestamps:
+            raise TrafficAttributionError(
+                f"clones.clones contains duplicate timestamp {timestamp}"
+            )
+        seen_timestamps.add(timestamp)
+        daily.append(
+            {
+                "timestamp": timestamp,
+                "clones": _non_negative_integer(
+                    row.get("count"), field=f"clones.clones[{index}].count"
+                ),
+                "uniqueCloners": _non_negative_integer(
+                    row.get("uniques"), field=f"clones.clones[{index}].uniques"
                 ),
             }
         )
@@ -299,6 +332,29 @@ def _window(
     }
 
 
+def _clone_date_relation_counts(
+    daily_clones: Sequence[Mapping[str, Any]], *, renamed_at: datetime
+) -> dict[str, int]:
+    rename_date = renamed_at.date()
+    counts = {
+        "preRenameDateClones": 0,
+        "renameDateClones": 0,
+        "postRenameDateClones": 0,
+    }
+    for row in daily_clones:
+        clone_date = parse_timestamp(
+            row["timestamp"], field="daily clone timestamp"
+        ).date()
+        if clone_date < rename_date:
+            key = "preRenameDateClones"
+        elif clone_date == rename_date:
+            key = "renameDateClones"
+        else:
+            key = "postRenameDateClones"
+        counts[key] += row["clones"]
+    return counts
+
+
 def _percentage(numerator: int, denominator: int) -> float | None:
     if denominator == 0:
         return 0.0 if numerator == 0 else None
@@ -320,6 +376,7 @@ def build_report(
     views_payload: Any,
     paths_payload: Any,
     referrers_payload: Any,
+    clones_payload: Any | None = None,
 ) -> dict[str, Any]:
     canonical = normalize_repository(repository, field="repository")
     if renamed_at > now:
@@ -346,6 +403,25 @@ def build_report(
     total_views = _non_negative_integer(views.get("count"), field="views.count")
     total_uniques = _non_negative_integer(views.get("uniques"), field="views.uniques")
     daily_views = _normalize_daily_views(views)
+    if clones_payload is None:
+        total_clones = None
+        total_unique_cloners = None
+        daily_clones: list[dict[str, Any]] = []
+        daily_clone_sum = None
+        clone_window = None
+        clone_date_relation_counts = None
+    else:
+        clones = _require_mapping(clones_payload, field="clones")
+        total_clones = _non_negative_integer(clones.get("count"), field="clones.count")
+        total_unique_cloners = _non_negative_integer(
+            clones.get("uniques"), field="clones.uniques"
+        )
+        daily_clones = _normalize_daily_clones(clones)
+        daily_clone_sum = sum(row["clones"] for row in daily_clones)
+        clone_window = _window(daily_clones, now=now, renamed_at=renamed_at)
+        clone_date_relation_counts = _clone_date_relation_counts(
+            daily_clones, renamed_at=renamed_at
+        )
     paths = _normalize_paths(
         paths_payload, canonical=canonical, legacy=deduplicated_legacy
     )
@@ -398,8 +474,35 @@ def build_report(
     return {
         "analyzedAt": format_timestamp(now),
         "apiVersion": API_VERSION,
+        "cloneTraffic": {
+            "available": clones_payload is not None,
+            "byDay": daily_clones,
+            "clones": total_clones,
+            "dailyClonesMatchTotal": (
+                daily_clone_sum == total_clones if clones_payload is not None else None
+            ),
+            "dailyClonesSum": daily_clone_sum,
+            "dailyUniqueClonersAdditive": False,
+            "dateRelationCounts": clone_date_relation_counts,
+            "fetchesIncluded": False if clones_payload is not None else None,
+            "fullClonesOnly": True if clones_payload is not None else None,
+            "requestedRepositorySlugAvailable": (
+                False if clones_payload is not None else None
+            ),
+            "scope": "repository-aggregate" if clones_payload is not None else None,
+            "slugAttributionAvailable": (False if clones_payload is not None else None),
+            "uniqueClonerAuthority": (
+                "clones.uniques" if clones_payload is not None else None
+            ),
+            "uniqueCloners": total_unique_cloners,
+            "window": clone_window,
+        },
         "interpretation": {
             "canonicalKnownTopPathViews": group_views["canonical"],
+            "cloneDemandInferred": False,
+            "cloneSlugAttributionAvailable": (
+                False if clones_payload is not None else None
+            ),
             "contentInterestInferred": False,
             "pathByDateAvailable": False,
             "status": status,
@@ -409,7 +512,9 @@ def build_report(
             "popular paths returns at most 10 rows",
             "path-level unique visitors overlap and are not additive",
             "GitHub does not expose path-by-date traffic",
-            "rename-day views cannot be split into pre-rename and redirect traffic",
+            "rename-day views cannot be split into pre-rename and post-rename traffic",
+            "clone traffic does not expose the requested canonical or legacy repository slug",
+            "daily unique cloners overlap and are not additive",
         ],
         "metricDefinitions": {
             "canonical_known_top_path_views": (
@@ -425,7 +530,9 @@ def build_report(
                 "views in returned popular paths matching neither canonical nor legacy boundaries"
             ),
             "top_path_coverage": "returned popular-path views divided by total repository views",
+            "total_clones": "rolling full-clone count from traffic/clones; fetches are excluded",
             "total_views": "rolling repository view count from traffic/views",
+            "unique_cloners": "authoritative rolling unique count from traffic/clones uniques",
             "unique_visitors": "authoritative rolling unique count from traffic/views uniques",
         },
         "metrics": {
@@ -434,7 +541,9 @@ def build_report(
             "not_in_top_paths_views": unattributed_views,
             "other_known_top_path_views": group_views["other"],
             "top_path_coverage": _ratio(listed_views, total_views),
+            "total_clones": total_clones,
             "total_views": total_views,
+            "unique_cloners": total_unique_cloners,
             "unique_visitors": total_uniques,
         },
         "pathAttribution": {
@@ -453,6 +562,7 @@ def build_report(
         },
         "referrers": referrers,
         "rawResponses": {
+            "clones": clones_payload,
             "popularPaths": paths_payload,
             "popularReferrers": referrers_payload,
             "views": views_payload,
@@ -462,10 +572,25 @@ def build_report(
             "renamedAt": format_timestamp(renamed_at),
         },
         "repository": canonical,
-        "schemaVersion": 1,
+        "schemaVersion": 2,
+        "sourceAvailability": {
+            "clones": clones_payload is not None,
+            "popularPaths": True,
+            "popularReferrers": True,
+            "views": True,
+        },
         "totals": {
+            "clones": total_clones,
+            "dailyClonesMatchTotal": (
+                daily_clone_sum == total_clones if clones_payload is not None else None
+            ),
+            "dailyClonesSum": daily_clone_sum,
             "dailyViewsMatchTotal": daily_sum == total_views,
             "dailyViewsSum": daily_sum,
+            "uniqueClonerAuthority": (
+                "clones.uniques" if clones_payload is not None else None
+            ),
+            "uniqueCloners": total_unique_cloners,
             "uniqueVisitorAuthority": "views.uniques",
             "uniqueVisitors": total_uniques,
             "views": total_views,
@@ -499,8 +624,9 @@ def _decision_text(status: str) -> str:
             "path-by-date cross-tab."
         ),
         "legacy-paths-after-rename-window": (
-            "Legacy paths remain after the rename window. Treat them as redirect or stale-link "
-            "traffic and investigate backlinks separately."
+            "Legacy-labelled paths remain after the rename window. GitHub does not document "
+            "whether these labels represent redirected requests or another analytics mapping, "
+            "so keep the mapping unverified and investigate backlinks separately."
         ),
         "incomplete-path-attribution": (
             "Popular paths do not fully and exclusively attribute the total. Keep canonical, "
@@ -516,6 +642,7 @@ def _decision_text(status: str) -> str:
 def render_markdown(report: Mapping[str, Any]) -> str:
     totals = report["totals"]
     attribution = report["pathAttribution"]
+    clone_traffic = report["cloneTraffic"]
     window = report["window"]
     rename = report["rename"]
     interpretation = report["interpretation"]
@@ -538,6 +665,9 @@ def render_markdown(report: Mapping[str, Any]) -> str:
         "| --- | ---: |",
         f"| Total repository views | {totals['views']} |",
         f"| Overall unique visitors | {totals['uniqueVisitors']} |",
+        f"| Total full clones | {totals['clones'] if totals['clones'] is not None else 'n/a'} |",
+        f"| Overall unique cloners | "
+        f"{totals['uniqueCloners'] if totals['uniqueCloners'] is not None else 'n/a'} |",
         f"| Canonical popular-path views | {groups['canonical']['views']} |",
         f"| Legacy popular-path views | {groups['legacy']['views']} |",
         f"| Other popular-path views | {groups['other']['views']} |",
@@ -579,6 +709,58 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             f"- Window overlaps rename: `{'yes' if window['windowOverlapsRename'] else 'no'}`",
             "- Path-by-date attribution: unavailable from the GitHub Traffic API",
             "",
+        ]
+    )
+    lines.extend(["## Clone traffic", ""])
+    if clone_traffic["available"]:
+        clone_window = clone_traffic["window"]
+        relation_counts = clone_traffic["dateRelationCounts"]
+        lines.extend(
+            [
+                f"- Rolling window: `{clone_window['startDateUtc']}` through "
+                f"`{clone_window['endDateUtc']}` UTC",
+                f"- Full clones: `{clone_traffic['clones']}`",
+                f"- Unique cloners: `{clone_traffic['uniqueCloners']}` from `clones.uniques`",
+                "- Fetches included: `no`",
+                "- Requested canonical/legacy clone URL available: `no`",
+                "- Canonical/legacy clone attribution: `unavailable`",
+                "",
+            ]
+        )
+        if not clone_traffic["dailyClonesMatchTotal"]:
+            lines.extend(
+                [
+                    "**Warning:** Daily clone buckets sum to "
+                    f"`{clone_traffic['dailyClonesSum']}`, but the endpoint total is "
+                    f"`{clone_traffic['clones']}`. Treat the date-relation breakdown as "
+                    "temporarily inconsistent.",
+                    "",
+                ]
+            )
+        lines.extend(
+            [
+                "| Clone date relation | Clones |",
+                "| --- | ---: |",
+                f"| Before rename UTC date | {relation_counts['preRenameDateClones']} |",
+                "| Rename UTC date (ambiguous within the day) | "
+                f"{relation_counts['renameDateClones']} |",
+                f"| After rename UTC date | {relation_counts['postRenameDateClones']} |",
+                "",
+                "Date relation is not slug attribution. GitHub does not return the repository "
+                "URL used for a clone, and daily unique-cloner counts are intentionally not summed.",
+                "",
+            ]
+        )
+    else:
+        lines.extend(
+            [
+                "Clone input was not supplied. Clone totals and slug-attribution constraints "
+                "cannot be evaluated in this offline compatibility mode.",
+                "",
+            ]
+        )
+    lines.extend(
+        [
             "## Popular referrers",
             "",
             "| Referrer | Views | Referrer uniques |",
@@ -601,7 +783,9 @@ def render_markdown(report: Mapping[str, Any]) -> str:
             "- `views` is the rolling repository total; it is not automatically a content-interest KPI.",
             "- Canonical, legacy, and other counts cover only the popular paths returned by GitHub.",
             "- Path-level unique counts are non-additive; use the overall unique visitor count above.",
-            "- A rename-day view cannot be split into pre-rename and post-redirect traffic.",
+            "- A rename-day view cannot be split into pre-rename and post-rename traffic.",
+            "- Clone totals are repository-level full clones and cannot be split by canonical "
+            "versus legacy clone URL.",
             "",
         ]
     )
@@ -624,6 +808,69 @@ def _atomic_write(path: Path, content: str) -> None:
             pass
 
 
+def _verify_archive(destination: Path, expected: Mapping[str, str]) -> None:
+    for name, content in expected.items():
+        path = destination / name
+        try:
+            existing = path.read_text(encoding="utf-8")
+        except FileNotFoundError as exc:
+            raise TrafficAttributionError(
+                f"archive directory is incomplete: {destination}"
+            ) from exc
+        except OSError as exc:
+            raise TrafficAttributionError(
+                f"could not read archive file {path}: {exc}"
+            ) from exc
+        if existing != content:
+            raise TrafficAttributionError(
+                f"archive file already exists with different content: {path}"
+            )
+
+
+def _archive_report(
+    directory: Path,
+    report: Mapping[str, Any],
+    *,
+    json_content: str,
+    markdown_content: str,
+) -> Path:
+    analyzed_at = parse_timestamp(report["analyzedAt"], field="analyzedAt")
+    archive_key = analyzed_at.strftime("%Y-%m-%dT%H%M%SZ")
+    destination = directory / archive_key
+    checksums = (
+        f"{hashlib.sha256(json_content.encode('utf-8')).hexdigest()}  snapshot.json\n"
+        f"{hashlib.sha256(markdown_content.encode('utf-8')).hexdigest()}  summary.md\n"
+    )
+    expected = {
+        "snapshot.json": json_content,
+        "summary.md": markdown_content,
+        "checksums.sha256": checksums,
+    }
+    directory.mkdir(parents=True, exist_ok=True)
+    if destination.exists():
+        _verify_archive(destination, expected)
+        return destination
+
+    staging = Path(tempfile.mkdtemp(prefix=f".{archive_key}.", dir=str(directory)))
+    try:
+        for name, content in expected.items():
+            _atomic_write(staging / name, content)
+        try:
+            os.rename(staging, destination)
+        except OSError as exc:
+            if not destination.exists():
+                raise TrafficAttributionError(
+                    f"could not publish archive directory {destination}: {exc}"
+                ) from exc
+            _verify_archive(destination, expected)
+        else:
+            staging = None
+    finally:
+        if staging is not None:
+            shutil.rmtree(staging, ignore_errors=True)
+    return destination
+
+
 def _parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description="Classify GitHub traffic across canonical and renamed repository paths."
@@ -643,7 +890,15 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--output-json", required=True, type=Path)
     parser.add_argument("--output-markdown", required=True, type=Path)
     parser.add_argument(
+        "--archive-directory",
+        type=Path,
+        help="Optional private directory for immutable timestamped output and checksums",
+    )
+    parser.add_argument(
         "--views-file", type=Path, help="Offline raw traffic/views JSON"
+    )
+    parser.add_argument(
+        "--clones-file", type=Path, help="Offline raw traffic/clones JSON"
     )
     parser.add_argument(
         "--paths-file", type=Path, help="Offline raw traffic/popular/paths JSON"
@@ -671,29 +926,50 @@ def main(argv: Sequence[str] | None = None) -> int:
         raise TrafficAttributionError(
             "renamed-at must not be later than the analysis timestamp"
         )
-    offline_paths = [args.views_file, args.paths_file, args.referrers_file]
-    if any(path is not None for path in offline_paths) and not all(
-        path is not None for path in offline_paths
+    required_offline_paths = [
+        args.views_file,
+        args.paths_file,
+        args.referrers_file,
+    ]
+    if any(path is not None for path in required_offline_paths) and not all(
+        path is not None for path in required_offline_paths
     ):
         raise TrafficAttributionError(
             "--views-file, --paths-file, and --referrers-file must be provided together"
+        )
+    if args.clones_file is not None and not all(
+        path is not None for path in required_offline_paths
+    ):
+        raise TrafficAttributionError(
+            "--clones-file requires --views-file, --paths-file, and --referrers-file"
         )
     output_paths = {args.output_json.resolve(), args.output_markdown.resolve()}
     if len(output_paths) != 2:
         raise TrafficAttributionError(
             "JSON and Markdown outputs must use different paths"
         )
-    if all(path is not None for path in offline_paths):
-        input_paths = {path.resolve() for path in offline_paths}
+    if all(path is not None for path in required_offline_paths):
+        supplied_input_paths = [
+            *required_offline_paths,
+            *([args.clones_file] if args.clones_file is not None else []),
+        ]
+        input_paths = {path.resolve() for path in supplied_input_paths}
         if output_paths & input_paths:
             raise TrafficAttributionError(
                 "output paths must not overwrite offline input files"
             )
         views_payload = _read_json(args.views_file, field="views file")
+        clones_payload = (
+            _read_json(args.clones_file, field="clones file")
+            if args.clones_file is not None
+            else None
+        )
         paths_payload = _read_json(args.paths_file, field="paths file")
         referrers_payload = _read_json(args.referrers_file, field="referrers file")
     else:
-        views_payload, paths_payload, referrers_payload = collect_live(repository)
+        views_payload, clones_payload, paths_payload, referrers_payload = collect_live(
+            repository
+        )
 
     report = build_report(
         repository=repository,
@@ -703,9 +979,20 @@ def main(argv: Sequence[str] | None = None) -> int:
         views_payload=views_payload,
         paths_payload=paths_payload,
         referrers_payload=referrers_payload,
+        clones_payload=clones_payload,
     )
-    _atomic_write(args.output_json, render_json(report))
-    _atomic_write(args.output_markdown, render_markdown(report))
+    json_content = render_json(report)
+    markdown_content = render_markdown(report)
+    if args.archive_directory is not None:
+        archive_path = _archive_report(
+            args.archive_directory,
+            report,
+            json_content=json_content,
+            markdown_content=markdown_content,
+        )
+        print(f"Archived private traffic evidence: {archive_path}", file=sys.stderr)
+    _atomic_write(args.output_json, json_content)
+    _atomic_write(args.output_markdown, markdown_content)
     return 0
 
 

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -14,14 +14,14 @@
         "react-dom": "^19.2.7"
       },
       "devDependencies": {
-        "@eslint/js": "^9.39.5",
+        "@eslint/js": "^10.0.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/node": "^24.13.3",
         "@types/react": "^19.2.17",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react": "^6.0.3",
-        "eslint": "^9.39.5",
+        "eslint": "^10.8.0",
         "eslint-plugin-react-hooks": "^7.1.1",
         "eslint-plugin-react-refresh": "^0.5.3",
         "globals": "^17.7.0",
@@ -570,118 +570,89 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.21.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.2.tgz",
-      "integrity": "sha512-nJl2KGTlrf9GjLimgIru+V/mzgSK0ABCDQRvxw5BjURL7WfH5uoWmizbH7QB6MmnMBd8cIC9uceWnezL1VZWWw==",
+      "version": "0.23.5",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.23.5.tgz",
+      "integrity": "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/object-schema": "^2.1.7",
+        "@eslint/object-schema": "^3.0.5",
         "debug": "^4.3.1",
-        "minimatch": "^3.1.5"
+        "minimatch": "^10.2.4"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/config-helpers": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.4.2.tgz",
-      "integrity": "sha512-gBrxN88gOIf3R7ja5K9slwNayVcZgK6SOUORm2uBzTeIEfeVaIhOpCtTox3P6R7o2jLFwLFTLnC7kU/RGcYEgw==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.7.0.tgz",
+      "integrity": "sha512-DObd/KKUsU+FaFv4PLxSRenpXfQWmPXXP3pPZ6/K1PCrMu2vQpMDMuQe/BqYeoLcz8ro0bVDF1RxOJgfVEdhUw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0"
+        "@eslint/core": "^1.2.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/core": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.17.0.tgz",
-      "integrity": "sha512-yL/sLrpmtDaFEiUj1osRP4TI2MDz1AddJL+jZ7KSqvBuliN4xqYY54IfdN8qD8Toa6g1iloph1fxQNkjOxrrpQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@eslint/core/-/core-1.2.1.tgz",
+      "integrity": "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@types/json-schema": "^7.0.15"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      }
-    },
-    "node_modules/@eslint/eslintrc": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.6.tgz",
-      "integrity": "sha512-l2Ul9PrHsPCKcEY/ac7VgFj9D80C7S68sOKc618SyHDPK36s1XcFebXY0iTzUVn4Yq+YbwvSnDmCz9yxjX+QrA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ajv": "^6.14.0",
-        "debug": "^4.3.2",
-        "espree": "^10.0.1",
-        "globals": "^14.0.0",
-        "ignore": "^5.2.0",
-        "import-fresh": "^3.2.1",
-        "js-yaml": "^4.3.0",
-        "minimatch": "^3.1.5",
-        "strip-json-comments": "^3.1.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/@eslint/eslintrc/node_modules/globals": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-      "integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.5.tgz",
-      "integrity": "sha512-QywQuszQh77pIXCsq998c8hbhSTI/azTty1Z6N53dmAudKHhy573j3yvRLsX2BSp8YpLtoCEG8E9DJe+8zUh4A==",
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
+      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
+      },
+      "peerDependencies": {
+        "eslint": "^10.0.0"
+      },
+      "peerDependenciesMeta": {
+        "eslint": {
+          "optional": true
+        }
       }
     },
     "node_modules/@eslint/object-schema": {
-      "version": "2.1.7",
-      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.7.tgz",
-      "integrity": "sha512-VtAOaymWVfZcmZbp6E2mympDIHvyjXs/12LqWYjVw6qjrfF+VK+fyG33kChz3nnK+SU5/NeHOqrTEHS8sXO3OA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-3.0.5.tgz",
+      "integrity": "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.4.1.tgz",
-      "integrity": "sha512-43/qtrDUokr7LJqoF2c3+RInu/t4zfrpYdoSDfYyhg52rwLV6TnOvdG4fXm7IkSB3wErkcmJS9iEhjVtOSEjjA==",
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.7.2.tgz",
+      "integrity": "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@eslint/core": "^0.17.0",
+        "@eslint/core": "^1.2.1",
         "levn": "^0.4.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
     "node_modules/@exodus/bytes": {
@@ -1249,6 +1220,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/esrecurse": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@types/esrecurse/-/esrecurse-4.3.1.tgz",
+      "integrity": "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1481,45 +1459,6 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.7",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "dev": true,
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
       "version": "7.8.5",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
@@ -1573,19 +1512,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/@vitejs/plugin-react": {
@@ -1728,9 +1654,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.17.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.17.0.tgz",
-      "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
+      "version": "8.18.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.18.0.tgz",
+      "integrity": "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ==",
       "dev": true,
       "license": "MIT",
       "bin": {
@@ -1778,29 +1704,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
-      "license": "Python-2.0"
-    },
     "node_modules/aria-query": {
       "version": "5.3.0",
       "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
@@ -1822,11 +1725,14 @@
       }
     },
     "node_modules/balanced-match": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
-      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.10.43",
@@ -1852,14 +1758,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
-      "integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "balanced-match": "^1.0.0",
-        "concat-map": "0.0.1"
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/browserslist": {
@@ -1896,16 +1804,6 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/caniuse-lite": {
       "version": "1.0.30001806",
       "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
@@ -1936,50 +1834,6 @@
       "engines": {
         "node": ">=18"
       }
-    },
-    "node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/concat-map": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/convert-source-map": {
       "version": "2.0.0",
@@ -2156,33 +2010,33 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.39.5",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.39.5.tgz",
-      "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
+      "version": "10.8.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
+      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
       "dev": true,
       "license": "MIT",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
-        "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.21.2",
-        "@eslint/config-helpers": "^0.4.2",
-        "@eslint/core": "^0.17.0",
-        "@eslint/eslintrc": "^3.3.6",
-        "@eslint/js": "9.39.5",
-        "@eslint/plugin-kit": "^0.4.1",
+        "@eslint-community/regexpp": "^4.12.2",
+        "@eslint/config-array": "^0.23.5",
+        "@eslint/config-helpers": "^0.7.0",
+        "@eslint/core": "^1.2.1",
+        "@eslint/plugin-kit": "^0.7.2",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
         "@humanwhocodes/retry": "^0.4.2",
         "@types/estree": "^1.0.6",
         "ajv": "^6.14.0",
-        "chalk": "^4.0.0",
         "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
-        "eslint-scope": "^8.4.0",
-        "eslint-visitor-keys": "^4.2.1",
-        "espree": "^10.4.0",
-        "esquery": "^1.5.0",
+        "eslint-scope": "^9.1.2",
+        "eslint-visitor-keys": "^5.0.1",
+        "espree": "^11.2.0",
+        "esquery": "^1.7.0",
         "esutils": "^2.0.2",
         "fast-deep-equal": "^3.1.3",
         "file-entry-cache": "^8.0.0",
@@ -2192,8 +2046,7 @@
         "imurmurhash": "^0.1.4",
         "is-glob": "^4.0.0",
         "json-stable-stringify-without-jsonify": "^1.0.1",
-        "lodash.merge": "^4.6.2",
-        "minimatch": "^3.1.5",
+        "minimatch": "^10.2.5",
         "natural-compare": "^1.4.0",
         "optionator": "^0.9.3"
       },
@@ -2201,7 +2054,7 @@
         "eslint": "bin/eslint.js"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://eslint.org/donate"
@@ -2246,48 +2099,50 @@
       }
     },
     "node_modules/eslint-scope": {
-      "version": "8.4.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-      "integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-9.1.2.tgz",
+      "integrity": "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
+        "@types/esrecurse": "^4.3.1",
+        "@types/estree": "^1.0.8",
         "esrecurse": "^4.3.0",
         "estraverse": "^5.2.0"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/eslint-visitor-keys": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-      "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
       "dev": true,
       "license": "Apache-2.0",
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
       }
     },
     "node_modules/espree": {
-      "version": "10.4.0",
-      "resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-      "integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
+      "version": "11.2.0",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-11.2.0.tgz",
+      "integrity": "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw==",
       "dev": true,
       "license": "BSD-2-Clause",
       "dependencies": {
-        "acorn": "^8.15.0",
+        "acorn": "^8.16.0",
         "acorn-jsx": "^5.3.2",
-        "eslint-visitor-keys": "^4.2.1"
+        "eslint-visitor-keys": "^5.0.1"
       },
       "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+        "node": "^20.19.0 || ^22.13.0 || >=24"
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
@@ -2500,16 +2355,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -2548,23 +2393,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 4"
-      }
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/imurmurhash": {
@@ -2630,29 +2458,6 @@
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/puzrin"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/nodeca"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
-      }
     },
     "node_modules/jsdom": {
       "version": "29.1.1",
@@ -3065,13 +2870,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/lodash.merge": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
-      "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3130,16 +2928,19 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "version": "10.2.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.6.tgz",
+      "integrity": "sha512-vpLQEs+VLCr1nU0BXS07maYoFwlDAH0gngQuuttxIwutDFEMHq2blX+8vpgxDdK3J1PwjCJiep77OitTZ4Ll1A==",
       "dev": true,
-      "license": "ISC",
+      "license": "BlueOak-1.0.0",
       "dependencies": {
-        "brace-expansion": "^1.1.7"
+        "brace-expansion": "^5.0.8"
       },
       "engines": {
-        "node": "*"
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
       }
     },
     "node_modules/ms": {
@@ -3247,19 +3048,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/parse5": {
@@ -3454,16 +3242,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
     "node_modules/rolldown": {
       "version": "1.1.5",
       "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.1.5.tgz",
@@ -3589,32 +3367,6 @@
       "license": "MIT",
       "dependencies": {
         "min-indent": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/strip-json-comments": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
-      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "has-flag": "^4.0.0"
       },
       "engines": {
         "node": ">=8"

--- a/web/package.json
+++ b/web/package.json
@@ -25,14 +25,14 @@
     "react-dom": "^19.2.7"
   },
   "devDependencies": {
-    "@eslint/js": "^9.39.5",
+    "@eslint/js": "^10.0.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/node": "^24.13.3",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react": "^6.0.3",
-    "eslint": "^9.39.5",
+    "eslint": "^10.8.0",
     "eslint-plugin-react-hooks": "^7.1.1",
     "eslint-plugin-react-refresh": "^0.5.3",
     "globals": "^17.7.0",


### PR DESCRIPTION
## What changed

- collect GitHub clone traffic alongside views, popular paths, and referrers
- keep canonical/legacy view-path attribution separate from repository-level clone totals
- preserve timestamped private evidence sets with SHA-256 checksums and atomic collision handling
- retain compatibility with existing three-file offline snapshots
- record the 2026-07-30 operational checkpoint, redirect identity verification, and the 331→332 rolling-window drift

## Why

The repository rename redirects both web and Git operations to the canonical repository, while GitHub Traffic still returns legacy-labelled popular paths. Clone responses contain no requested URL or slug, so clone totals cannot be allocated to the old and new repository names. The prior collector did not capture that limitation or preserve clone evidence.

## Impact

Operators now receive an auditable 14-day report that keeps canonical views, legacy-labelled views, aggregate full clones, and referrers distinct. The report explicitly avoids treating mixed-path views or aggregate clones as canonical-name demand.

## Checks

- `ruff check tools/github`
- `ruff format --check tools/github`
- `make repository-traffic-test` — 23 tests
- concurrent archive collision test repeated 20 times
- live `make repository-traffic` — 12 views, 1 unique visitor, 3 canonical views, 9 legacy-labelled views, 332 full clones, 109 unique cloners
- archived snapshot and Markdown SHA-256 verification

## CI follow-up

A newly published high-severity `brace-expansion` advisory caused the frontend audit gate to fail after this PR opened. The remediation updates the development-only lint toolchain to `eslint` 10.8.0 and `@eslint/js` 10.0.1; all existing ESLint plugins declare ESLint 10 support.

Additional checks:

- clean `npm ci`
- ESLint 10 lint pass
- 5 frontend test files / 30 tests pass
- Vite production build pass
- `npm audit --audit-level=high` — 0 vulnerabilities
